### PR TITLE
FEATURE: Ignore most of repo when downloading as bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,16 @@
   "authors": [
     "GoodData A-players <da@gooddata.com>"
   ],
+  "ignore": [
+    "ci",
+    "examples",
+    "coverage",
+    "lib",
+    "src",
+    "test",
+    "tools",
+    "package.json"
+  ],
   "description": "GoodData JS SDK",
   "main": "dist/gooddata-js.min.js",
   "license": "GoodLicense",


### PR DESCRIPTION
I've found out we can actually force bower to download only necessary parts of the repo while consuming it as a package - see https://github.com/bower/bower.json-spec#ignore

So let's do this - no one using sdk as a packaged IMHO needs anything from the list presented.
