### PR TITLE
FEATURE: CL-4635 CORS Support for xhr

### DIFF
--- a/examples/sdk-cors-example/index.html
+++ b/examples/sdk-cors-example/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"
+   "http://www.w3.org/TR/html4/strict.dtd">
+
+<html lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>GoodData JS Project Template</title>
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="copyright" content="Copyright © 2008 - 2013 GoodData Corporation. All rights reserved.">
+
+</head>
+<body class="app" bgcolor="#ffffff" style="display:block">
+
+    <h1>All your datasets</h1>
+    <div id="root" class="app">
+        <ul id="datasets"></ul>
+    </div>
+
+    <!-- Dendencies of your project can be specified here -->
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+    <script src="../gooddata.js"></script>
+    <script src="project.js"></script>
+
+    </body>
+</html>

--- a/examples/sdk-cors-example/project.js
+++ b/examples/sdk-cors-example/project.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2007-2013, GoodData(R) Corporation. All rights reserved.
+var projectId = '', // Your project ID
+    user = '',
+    passwd = '';
+
+
+// Fill in your gooddata CORS enabled url (e.g. https://gd.domain.tld)
+gooddata.config.setCustomDomain('<your_gooddata_endpoint>');
+
+// Show login info
+$('#root').append('<div class="login-loader">Logging in...</div>');
+
+gooddata.user.login(user, passwd).then(function() {
+    // Loged in
+    $('div.login-loader').remove();
+    $('#root').append('<div class="loading">Logged in... Loading dataSets</div>');
+
+    // Do your stuff here
+    // ...
+    gooddata.project.getDatasets(projectId).then(function(dataSets) {
+        $('.loading').remove();
+        dataSets.forEach(function(ds) {
+            $('#datasets').append('<li>'+ds.title+'</li>');
+        });
+    });
+});

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2007-2014, GoodData(R) Corporation. All rights reserved.
+define([
+], function(
+) {
+    'use strict';
+    /**
+     * Config module holds SDK configuration variables
+     *
+     * Currently its only custom domain - which enabled using
+     * sdk from different domain (using CORS)
+     *
+     * Never set properties directly - always use setter methods
+     *
+     * @module config
+     * @class config
+     */
+
+    var module = { domain: undefined },
+        r = '(?:(https)://+|(www\\.)?)\\w[:;,\\.?\\[\\]\\w/~%&=+#-@!]*';
+
+    /**
+     * Sets custom domain. Parameter is url which has always to be https://
+     * (if you don't provide it, we will do it for you).
+     *
+     * RegExp inspired taken from
+     * https://github.com/jarib/google-closure-library/blob/master/closure/goog/string/linkify.js
+     *
+     * @method setCustomDomain
+     */
+    var setCustomDomain = function(d) {
+        var link = d.match(r);
+
+        if (!link) {
+            throw new Error(d + ' is not a valid url');
+        }
+
+        // ensure https:// prefix
+        // and strip possible trailing /
+        module.domain = 'https://' + link[0]
+                        .replace(/^https:\/\//, '')
+                        .replace(/\/$/, '');
+    };
+
+    module.setCustomDomain = setCustomDomain;
+
+    return module;
+});
+
+

--- a/src/gooddata.js
+++ b/src/gooddata.js
@@ -5,14 +5,16 @@ define([
     'user',
     'metadata',
     'execution',
-    'project'
+    'project',
+    'config'
 ], function(
     xhr,
     util,
     user,
     metadata,
     execution,
-    project
+    project,
+    config
 ) {
     'use strict';
 
@@ -38,6 +40,7 @@ define([
      * @class sdk
      */
     return {
+        config: config,
         xhr: xhr,
         user: user,
         md: metadata,

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2007-2014, GoodData(R) Corporation. All rights reserved.
+define(['config'], function(config) {
+    'use strict';
+    describe('config', function() {
+
+        describe('setCustomDomain', function() {
+            afterEach(function() {
+                config.domain = undefined;
+            });
+            it('should set url if valid', function() {
+                config.setCustomDomain('https://custom.domain.tld/');
+                expect(config.domain).to.be('https://custom.domain.tld');
+
+                config.setCustomDomain('custom.domain.tld');
+                expect(config.domain).to.be('https://custom.domain.tld');
+
+                config.setCustomDomain('www.domain.tld');
+                expect(config.domain).to.be('https://www.domain.tld');
+            });
+            it('should strip trailing uri', function() {
+                config.setCustomDomain('https://custom.domain.tld/');
+                expect(config.domain).to.be('https://custom.domain.tld');
+            });
+            it('should strip trailing whitespace', function() {
+                config.setCustomDomain("   https://custom.domain.tld/  \n");
+                expect(config.domain).to.be('https://custom.domain.tld');
+            });
+            it('should throw with invalid url', function() {
+                expect(function () {
+                    config.setCustomDomain('$');
+                }).to.throwError();
+            });
+        });
+    });
+});
+
+

--- a/test/xhr_test.js
+++ b/test/xhr_test.js
@@ -132,7 +132,7 @@ define(['gooddata', 'jquery'], function(gd, $) {
                 d[2].resolve('Hello', '', mockResponse(200)); //request retry
             });
 
-            it('should fail if token renewail fails and unathorize handler is not set', function(done) {
+            it('should fail if token renewal fails and unathorize handler is not set', function(done) {
                 var options = { url: '/some/url'};
                 xhr.ajax(options).fail(function(xhr) {
                     expect(xhr.status).to.be(401);
@@ -310,6 +310,27 @@ define(['gooddata', 'jquery'], function(gd, $) {
                     data: data,
                     contentType: 'text/csv'
                 }]);
+            });
+        });
+
+        describe('enrichSettingWithCustomDomain', function() {
+            it('should not touch settings if no domain set', function() {
+                var settings = { url: '/test1' },
+                    res = xhr.enrichSettingWithCustomDomain(settings, undefined);
+                expect(res.url).to.be('/test1');
+                expect(res.xhrFields).to.be(undefined);
+            });
+            it('should add domain before url', function() {
+                var settings = { url: '/test1' },
+                    res = xhr.enrichSettingWithCustomDomain(settings, 'https://domain.tld');
+                expect(res.url).to.be('https://domain.tld/test1');
+                expect(res.xhrFields).to.eql({ withCredentials: true });
+            });
+            it('should not double domain in settings url', function() {
+                var settings = { url: 'https://domain.tld/test1' },
+                    res = xhr.enrichSettingWithCustomDomain(settings, 'https://domain.tld');
+                expect(res.url).to.be('https://domain.tld/test1');
+                expect(res.xhrFields).to.eql({ withCredentials: true });
             });
         });
     });


### PR DESCRIPTION
All URLs in api calls were now only uri path part - anyone wanting to use sdk
from different domain couldn't do so.

Adds "statefull" config module with custom domain setter which stores domain
set by setCustomDomain setter. Xhr module depends on this module and enriches
xhr.ajax call settings object with necessary key and prepends domain to
settings.url.

Also adds really simple example of cors usage.

Dependency of xhr module could make someone unhappy while trying to reuse it
in our codebase.
