### PR TITLE
Add 'repository' field to package.json to avoid npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "author": "GoodData",
   "description": "GoodData JavaScript SDK",
   "license": "Copyright (c) 2014, GoodData Corporation (BSD License)",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:gooddata/gooddata-js.git"
+  },
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-uglify": "~0.1.0",


### PR DESCRIPTION
As of v1.2.20, npm throws annoying warning when there is no `"repository"` field present in the `package.json` file (try running `npm install`). This should fix it.

<3