### PR TITLE
BUGFIX: CL-6031 Fixed the 'indentifier not found' issue

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -435,14 +435,14 @@ define(['xhr', 'util'], function(xhr, util) {
                 return getObjectDetails(found[0].uri);
             }
 
-            d.reject('identifier not found');
+            return $.Deferred().reject('identifier not found');
         }, d.reject).then(function(objData) {
             if (!objData.attributeDisplayForm) {
                 return d.resolve(uriFinder(objData));
             } else {
                 return getObjectDetails(objData.attributeDisplayForm.content.formOf).then(function(objData) {
-                            d.resolve(uriFinder(objData));
-                        }, d.reject);
+                    d.resolve(uriFinder(objData));
+                }, d.reject);
             }
         }, d.reject);
 

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -162,6 +162,89 @@ define(['metadata', 'jquery'], function(md, $) {
                 });
             });
 
+            describe('getObjectUri', function() {
+                it('should return uri when identifier exists', function(done) {
+                    this.server.respondWith(
+                        'POST',
+                        '/gdc/md/myFakeProjectId/identifiers',
+                        [200, {'Content-Type': 'application/json'},
+                            JSON.stringify({
+                                identifiers: [{
+                                    uri: '/foo/bar',
+                                    identifier: 'attr.foo.bar'
+                                }]
+                            })]
+                    );
+
+                    this.server.respondWith(
+                        '/foo/bar',
+                        [200, {'Content-Type': 'application/json'},
+                            JSON.stringify({ attribute: { meta: { uri: '/foo/bar/attr' } } })]
+                    );
+
+                    md.getObjectUri('myFakeProjectId', 'attr.foo.bar').then(function(result) {
+                        expect(result).to.be('/foo/bar/attr');
+                        done();
+                    });
+                });
+
+                it('should reject promise when identifier does not exist', function(done) {
+                    this.server.respondWith(
+                        'POST',
+                        '/gdc/md/myFakeProjectId/identifiers',
+                        [200, {'Content-Type': 'application/json'},
+                            JSON.stringify({ identifiers: []})]
+                    );
+
+                    md.getObjectUri('myFakeProjectId', 'foo.bar').then(function() {
+                        expect().fail('Should reject with 404');
+                    }, function(err) {
+                        expect(err).to.be('identifier not found');
+                        done();
+                    });
+                });
+
+                it('should return an attribute uri for a display form identifier', function(done) {
+                    this.server.respondWith(
+                        'POST',
+                        '/gdc/md/myFakeProjectId/identifiers',
+                        [200, {'Content-Type': 'application/json'},
+                            JSON.stringify({ identifiers: [{
+                                    uri: '/foo/bar/label',
+                                    identifier: 'label.foo.bar'
+                            }] })]
+                    );
+
+                    this.server.respondWith(
+                        '/foo/bar/label',
+                        [200, {'Content-Type': 'application/json'},
+                            JSON.stringify({
+                                attributeDisplayForm: {
+                                    content: {
+                                        formOf: '/foo/bar'
+                                    },
+                                    meta: {
+                                        identifier: 'label.foo.bar',
+                                        uri: '/foo/bar/label',
+                                        title: 'Foo Bar Label'
+                                    }
+                                }
+                            })]
+                    );
+
+                    this.server.respondWith(
+                        '/foo/bar',
+                        [200, {'Content-Type': 'application/json'},
+                            JSON.stringify({ attribute: { meta: { uri: '/foo/bar/attr' } } })]
+                    );
+
+                    md.getObjectUri('myFakeProjectId', 'label.foo.bar').then(function(result) {
+                        expect(result).to.be('/foo/bar/attr');
+                        done();
+                    });
+                });
+            });
+
         });
     });
 });

--- a/test/xhr_test.js
+++ b/test/xhr_test.js
@@ -116,7 +116,7 @@ define(['gooddata', 'jquery'], function(gd, $) {
                 d[0].reject(mockResponse(404));
             });
 
-            it.only('should have accept header set on application/json', function() {
+            it('should have accept header set on application/json', function() {
                 xhr.ajax({ url: '/some/url'}).done(function(data, textStatus, xhr) {
                     expect(expects[0].calledOnce).to.be.ok();
                     expect(xhr.status).to.be(200);


### PR DESCRIPTION
- Added getObjectUri('df.id') -> `df.formOf.uri' test
