### PR TITLE
BUGFIX: CL-7896 Support headers in executionResult

### DIFF
--- a/src/execution.js
+++ b/src/execution.js
@@ -51,25 +51,30 @@ define(['jquery', './xhr'], function($, xhr) {
         xhr.post('/gdc/internal/projects/'+projectId+'/experimental/executions', {
             data: JSON.stringify(request)
         }, d.reject).then(function(result) {
-            // Populate result's header section
-            executedReport.headers = result.executionResult.columns.map(function(col) {
-                if (col.attributeDisplayForm) {
-                    return {
-                        type: 'attrLabel',
-                        id: col.attributeDisplayForm.meta.identifier,
-                        uri: col.attributeDisplayForm.meta.uri,
-                        title: col.attributeDisplayForm.meta.title
-                    };
-                } else {
-                    return {
-                        type: 'metric',
-                        id: col.metric.meta.identifier,
-                        uri: col.metric.meta.uri,
-                        title: col.metric.meta.title,
-                        format: col.metric.content.format
-                    };
-                }
-            });
+            // TODO: when executionResult.headers will be globaly available columns map code should be removed
+            if (result.executionResult.headers) {
+                executedReport.headers = result.executionResult.headers;
+            } else {
+                // Populate result's header section if is not available
+                executedReport.headers = result.executionResult.columns.map(function(col) {
+                    if (col.attributeDisplayForm) {
+                        return {
+                            type: 'attrLabel',
+                            id: col.attributeDisplayForm.meta.identifier,
+                            uri: col.attributeDisplayForm.meta.uri,
+                            title: col.attributeDisplayForm.meta.title
+                        };
+                    } else {
+                        return {
+                            type: 'metric',
+                            id: col.metric.meta.identifier,
+                            uri: col.metric.meta.uri,
+                            title: col.metric.meta.title,
+                            format: col.metric.content.format
+                        };
+                    }
+                });
+            }
             // Start polling on url returned in the executionResult for tabularData
             return xhr.ajax(result.executionResult.tabularDataResult);
         }, d.reject).then(function(result) {

--- a/test/execution_test.js
+++ b/test/execution_test.js
@@ -22,7 +22,7 @@ define(['execution'], function(ex) {
                                         meta: {
                                             identifier: 'attrId',
                                             uri: 'attrUri',
-                                            title: 'title'
+                                            title: 'Df Title'
                                         }
                                     }
                                 },
@@ -30,7 +30,8 @@ define(['execution'], function(ex) {
                                     metric: {
                                         meta: {
                                             identifier: 'metricId',
-                                            uri: 'metricUri'
+                                            uri: 'metricUri',
+                                            title: 'Metric Title'
                                         },
                                         content: {
                                             format: '#00'
@@ -44,7 +45,7 @@ define(['execution'], function(ex) {
                 });
 
                 describe('getData', function() {
-                    it('should resolve with JSON with correct data', function(done) {
+                    it('should resolve with JSON with correct data without headers', function(done) {
                         this.server.respondWith(
                             '/gdc/internal/projects/myFakeProjectId/experimental/executions',
                             [200, {'Content-Type': 'application/json'},
@@ -58,8 +59,60 @@ define(['execution'], function(ex) {
 
                         ex.getData('myFakeProjectId', ['attrId', 'metricId']).then(function(result) {
                             expect(result.headers[0].id).to.be('attrId');
+                            expect(result.headers[0].uri).to.be('attrUri');
+                            expect(result.headers[0].type).to.be('attrLabel');
+                            expect(result.headers[0].title).to.be('Df Title');
                             expect(result.headers[1].id).to.be('metricId');
                             expect(result.headers[1].uri).to.be('metricUri');
+                            expect(result.headers[1].type).to.be('metric');
+                            expect(result.headers[1].title).to.be('Metric Title');
+                            expect(result.rawData[0]).to.be('a');
+                            expect(result.rawData[1]).to.be(1);
+                            done();
+                        }, function(err) {
+                            expect().fail('Should resolve with CSV data');
+                            done();
+                        });
+                    });
+
+                    it('should resolve with JSON with correct data including headers', function(done) {
+                        var responseMock = JSON.parse(JSON.stringify(this.serverResponseMock));
+
+                        responseMock.executionResult.headers = [
+                            {
+                                id: 'attrId',
+                                title: 'Atribute Title',
+                                type: 'attrLabel',
+                                uri: 'attrUri'
+                            },
+                            {
+                                id: 'metricId',
+                                title: 'Metric Title',
+                                type: 'metric',
+                                uri: 'metricUri'
+                            }
+                        ];
+
+                        this.server.respondWith(
+                            '/gdc/internal/projects/myFakeProjectId/experimental/executions',
+                            [200, {'Content-Type': 'application/json'},
+                            JSON.stringify(responseMock)]
+                        );
+                        this.server.respondWith(
+                            /\/gdc\/internal\/projects\/myFakeProjectId\/experimental\/executions\/(\w+)/,
+                            [201, {'Content-Type': 'application/json'},
+                            JSON.stringify({'tabularDataResult': {values: ['a', 1]}})]
+                        );
+
+                        ex.getData('myFakeProjectId', ['attrId', 'metricId']).then(function(result) {
+                            expect(result.headers[0].id).to.be('attrId');
+                            expect(result.headers[0].uri).to.be('attrUri');
+                            expect(result.headers[0].type).to.be('attrLabel');
+                            expect(result.headers[0].title).to.be('Atribute Title');
+                            expect(result.headers[1].id).to.be('metricId');
+                            expect(result.headers[1].uri).to.be('metricUri');
+                            expect(result.headers[1].type).to.be('metric');
+                            expect(result.headers[1].title).to.be('Metric Title');
                             expect(result.rawData[0]).to.be('a');
                             expect(result.rawData[1]).to.be(1);
                             done();


### PR DESCRIPTION
- we added headers transformation to simpleexecutor because correctly we would like to have attribute titles in axes not display form titles. But we have in columns only display forms so we added directly headers transformation to resource and return in attrLabel attribute title.