### PR TITLE
RELATED: CL-9573 Refactor sorting of metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "webpack-dev-server": "1.12.1"
   },
   "dependencies": {
+    "invariant": "2.2.1",
     "lodash": "4.11.0",
     "md5": "2.1.0"
   }

--- a/src/utils/rules.js
+++ b/src/utils/rules.js
@@ -1,0 +1,20 @@
+import invariant from 'invariant';
+import { find, every } from 'lodash';
+
+export default class Rules {
+    constructor() {
+        this.rules = [];
+    }
+
+    addRule(tests, callback) {
+        this.rules.push([tests, callback]);
+    }
+
+    match(subject) {
+        const [, callback] = find(this.rules, ([tests]) => every(tests, test => test(subject)));
+
+        invariant(callback, 'Callback not found :-(');
+
+        return callback;
+    }
+}


### PR DESCRIPTION
No hashing of items necessary. Lot of `partial` magic removed.