### PR TITLE
RELATED: CL-9038 use measure column instead of generated PoP column for sorting

### DIFF
--- a/src/execution.js
+++ b/src/execution.js
@@ -194,7 +194,7 @@ const getDate = mdObj => (getDateCategory(mdObj) || getDateFilter(mdObj));
 
 const createPureMetric = measure => ({
     element: get(measure, 'objectUri'),
-    sort: !measure.showPoP ? get(measure, 'sort') : null
+    sort: get(measure, 'sort')
 });
 
 const createDerivedMetric = measure => {
@@ -272,8 +272,7 @@ const createPoPMetric = (measure, mdObj) => {
                 title,
                 format
             }
-        },
-        sort: get(measure, 'sort')
+        }
     }];
 
     if (generated) {
@@ -307,8 +306,7 @@ const createContributionPoPMetric = (measure, mdObj) => {
                 title,
                 format
             }
-        },
-        sort: get(measure, 'sort')
+        }
     }];
 
     result.push(generated);

--- a/test/execution_test.js
+++ b/test/execution_test.js
@@ -539,6 +539,23 @@ describe('execution', () => {
                     executionConfiguration
                 );
             });
+
+            it('doesn\'t set sort data on generated PoP column', () => {
+                mdObj.measures[0].measure.showPoP = true;
+                mdObj.measures = mdObj.measures.slice(1);
+
+                const executionConfiguration = ex.mdToExecutionConfiguration(mdObj);
+
+                expectOrderBy(
+                    [
+                        {
+                            column: '/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/1028',
+                            direction: 'asc'
+                        }
+                    ],
+                    executionConfiguration
+                );
+            });
         });
 
         describe('generating contribution metric', () => {


### PR DESCRIPTION
Hi @vaclavbohac, @dprentis 

this PR is changing how `orderBy` part of execution payload is created:
1. sort is not happening on generated columns (eg on PoP column) but on column/values for which the generated column was created (measure wit showPoP flag set to true)
2. sorting on generated columns is now not possible (would need changes in MD or accept values other than `asc' or 'desc')

this change is needed for [CL-9038](https://jira.intgdc.com/browse/CL-9038?filter=-3)

Petr