### PR TITLE
RELATED: ONE-1993 Wrap filters in "$and" to support multiple filters of same type

### DIFF
--- a/src/execution.js
+++ b/src/execution.js
@@ -437,10 +437,19 @@ const isAttributeFilterExecutable = listAttributeFilter =>
 
 
 function getWhere(filters) {
-    const attributeFilters = map(filter(filters, ({ listAttributeFilter }) => isAttributeFilterExecutable(listAttributeFilter)), attributeFilterToWhere);
+    const executableFilters = filter(filters, ({ listAttributeFilter }) => isAttributeFilterExecutable(listAttributeFilter));
+    const attributeFilters = map(executableFilters, attributeFilterToWhere);
     const dateFilters = map(filter(filters, ({ dateFilter }) => isDateFilterExecutable(dateFilter)), dateFilterToWhere);
 
-    return [...attributeFilters, ...dateFilters].reduce(assign, {});
+    const resultDate = [...dateFilters].reduce(assign, {});
+    const resultAttribute = {
+        $and: attributeFilters
+    };
+
+    return {
+        ...resultDate,
+        ...resultAttribute
+    };
 }
 
 const sortToOrderBy = item => ({ column: get(item, 'element'), direction: get(item, 'sort') });

--- a/test/execution_test.js
+++ b/test/execution_test.js
@@ -428,17 +428,21 @@ describe('execution', () => {
                 }, execConfig);
 
                 expectWhereCondition({
-                    '/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/1028': {
-                        '$in': [
-                            { 'id': 1243 },
-                            { 'id': 1242 },
-                            { 'id': 1241 },
-                            { 'id': 1240 },
-                            { 'id': 1239 },
-                            { 'id': 1238 },
-                            { 'id': 1236 }
-                        ]
-                    },
+                    $and: [
+                        {
+                            '/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/1028': {
+                                '$in': [
+                                    { 'id': 1243 },
+                                    { 'id': 1242 },
+                                    { 'id': 1241 },
+                                    { 'id': 1240 },
+                                    { 'id': 1239 },
+                                    { 'id': 1238 },
+                                    { 'id': 1236 }
+                                ]
+                            }
+                        }
+                    ],
                     '/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/16561': {
                         '$between': [-3, 0],
                             '$granularity': 'GDC.time.week'
@@ -481,17 +485,19 @@ describe('execution', () => {
                 }, execConfig);
 
                 expectWhereCondition({
-                    '/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/1028': {
-                        '$in': [
-                            { 'id': 1243 },
-                            { 'id': 1242 },
-                            { 'id': 1241 },
-                            { 'id': 1240 },
-                            { 'id': 1239 },
-                            { 'id': 1238 },
-                            { 'id': 1236 }
-                        ]
-                    },
+                    $and: [{
+                        '/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/1028': {
+                            '$in': [
+                                { 'id': 1243 },
+                                { 'id': 1242 },
+                                { 'id': 1241 },
+                                { 'id': 1240 },
+                                { 'id': 1239 },
+                                { 'id': 1238 },
+                                { 'id': 1236 }
+                            ]
+                        }
+                    }],
                     '/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/16561': {
                         '$between': [-3, 0],
                         '$granularity': 'GDC.time.week'
@@ -509,7 +515,7 @@ describe('execution', () => {
                 }];
 
                 const executionConfiguration = ex.mdToExecutionConfiguration(mdWithAllTime);
-                expect(executionConfiguration.where).to.eql({});
+                expect(executionConfiguration.where).to.eql({ $and: [] });
             });
 
             it('does not execute attribute filter with all selected', () => {
@@ -526,7 +532,7 @@ describe('execution', () => {
                 }];
 
                 const executionConfiguration = ex.mdToExecutionConfiguration(mdWithSelectAll);
-                expect(executionConfiguration.where).to.eql({});
+                expect(executionConfiguration.where).to.eql({ $and: [] });
             });
 
             it('generates right metricMappings', () => {


### PR DESCRIPTION
Filters are no longer assigned to a map on the basis of their
displayForm uri and all attribute filters are passed to backend in an
$and clause. This way, we keep backend to combine filter values when
it's already implemented there.

Specification: https://docs.google.com/presentation/d/1n2GA3vU7MagTODxWyxxaowG3fP9m3v6rNhp6xMxcHdw/edit#slide=id.g113d5c850e_0_0