### PR TITLE
FEATURE: CL-10935 Enable extended report execution results

### DIFF
--- a/src/execution.js
+++ b/src/execution.js
@@ -68,9 +68,11 @@ const wrapMeasureIndexesFromMappings = (metricMappings, headers) => {
  *                 property "where" containing query-like filters
  *                 property "orderBy" contains array of sorted properties to order in form
  *                      [{column: 'identifier', direction: 'asc|desc'}]
- * @param {Object} settings - AJAX settings. Set "extended" to true to retrieve the result
-                              including internal attribute IDs (useful to construct filters
-                              for subsequent report execution requests)
+ * @param {Object} settings - Set "extended" to true to retrieve the result
+ *                            including internal attribute IDs (useful to construct filters
+ *                            for subsequent report execution requests).
+ *                             Supports additional settings accepted by the underlying
+ *                             xhr.ajax() calls
  *
  * @return {Object} Structure with `headers` and `rawData` keys filled with values from execution.
  */
@@ -83,7 +85,6 @@ export function getData(projectId, columns, executionConfiguration = {}, setting
     // be used when constructing executionConfiguration filters for
     // subsequent report execution requests
     const resultKey = settings.extended ? 'extendedTabularDataResult' : 'tabularDataResult';
-
     // Create request and result structures
     const request = {
         execution: { columns }
@@ -127,8 +128,8 @@ export function getData(projectId, columns, executionConfiguration = {}, setting
         const { result, status } = r;
 
         return Object.assign({}, executedReport, {
-            rawData: get(result, resultKey + '.values', []),
-            warnings: get(result, resultKey + '.warnings', []),
+            rawData: get(result, `${resultKey}.values`, []),
+            warnings: get(result, `${resultKey}.warnings`, []),
             isLoaded: true,
             isEmpty: status === 204
         });


### PR DESCRIPTION
The public Javascript SDK uses the experimental/executions API that can provide results in two forms:
- Tabular form with attribute and metric values
- Extended tabular form that also includes the internal attribute element IDs

Unfortunately, the SDK always returns data in the tabular form. This PR adds the `extended` option to the `executions.getData` function makes the `getData` function to return data in the extended format.

The internal attribute element IDs are useful when you want to use the retrieve results to generate a filter for subsequent execution requests.