### PR TITLE
RELATED: RAIL-1118 Propagate requested measure format from visualizationObject to AFM

### DIFF
--- a/src/DataLayer/converters/MeasureConverter.ts
+++ b/src/DataLayer/converters/MeasureConverter.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2018 GoodData Corporation
 import compact = require('lodash/compact');
+import get = require('lodash/get');
 import { AFM, VisualizationObject } from '@gooddata/typings';
 import IMeasure = VisualizationObject.IMeasure;
 import IMeasureDefinition = VisualizationObject.IMeasureDefinition;
@@ -22,7 +23,7 @@ function convertMeasure(measure: IMeasure): AFM.IMeasure {
 
     const convertedDefinition = convertMeasureDefinition(definition);
 
-    const format = convertMeasureDefinitionFormat(definition);
+    const format = getFormat(measure);
     const formatProp = format ? { format } : {};
 
     const alias = measure.measure.alias ? measure.measure.alias : measure.measure.title;
@@ -147,14 +148,18 @@ function convertPreviousPeriodMeasureDefinition(definition: IPreviousPeriodMeasu
     };
 }
 
-function convertMeasureDefinitionFormat(definition: IMeasureDefinitionType): string | null {
-    if (VisualizationObject.isMeasureDefinition(definition)) {
-        return convertSimpleMeasureDefinitionFormat(definition);
-    }
-    return null;
+function getFormat(measure: IMeasure): string | undefined {
+    const { measure: { definition } } = measure;
+    const measureFormat = get(measure.measure, 'format');
+
+    const predefinedFormat = VisualizationObject.isMeasureDefinition(definition)
+        ? getPredefinedFormat(definition)
+        : undefined;
+
+    return predefinedFormat || measureFormat;
 }
 
-function convertSimpleMeasureDefinitionFormat(definition: IMeasureDefinition): string | null {
+function getPredefinedFormat(definition: IMeasureDefinition): string | null {
     const { measureDefinition } = definition;
     // should we prefer format defined on measure? If so, fix computeRatio format in AD
     return measureDefinition.computeRatio

--- a/src/DataLayer/converters/tests/MeasureConverter.spec.ts
+++ b/src/DataLayer/converters/tests/MeasureConverter.spec.ts
@@ -16,9 +16,9 @@ describe('convertMeasure', () => {
         });
     });
 
-    it('should ignore format defined on simple measures', () => {
+    it('should convert simple measure with format', () => {
         expect(MeasureConverter.convertMeasure(measures.simpleMeasureWithFormat)).toEqual({
-            ...afm.simpleMeasure
+            ...afm.simpleMeasureWithFormat
         });
     });
 

--- a/src/DataLayer/converters/tests/fixtures/Afm.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/Afm.fixtures.ts
@@ -44,6 +44,27 @@ export const simpleMeasure: IFixture = {
     }
 };
 
+export const simpleMeasureWithFormat: IFixture = {
+    afm: {
+        measures: [
+            {
+                localIdentifier: 'm1',
+                definition: {
+                    measure: {
+                        item: {
+                            uri: METRIC_URI
+                        }
+                    }
+                },
+                alias: 'Measure M1',
+                format: 'GD #,##0.00000'
+            }
+        ]
+    },
+    resultSpec: {
+    }
+};
+
 export const simpleMeasureWithIdentifiers: IFixture = {
     afm: {
         measures: [
@@ -529,7 +550,8 @@ export const stackingAttribute: IFixture = {
                         aggregation: 'sum'
                     }
                 },
-                alias: 'Sum of Bundle cost'
+                alias: 'Sum of Bundle cost',
+                format: '#,##0.00'
             }
         ],
         attributes: [
@@ -786,7 +808,8 @@ export const oneMeasureOneAttribute: IFixture = {
                         }
                     }
                 },
-                alias: 'Sum of Bundle cost'
+                alias: 'Sum of Bundle cost',
+                format: '#,##0.00'
             }
         ],
         attributes: [
@@ -814,7 +837,8 @@ export const oneMeasureOneAttributeWithIdentifiers: IFixture = {
                         }
                     }
                 },
-                alias: 'Sum of Bundle cost'
+                alias: 'Sum of Bundle cost',
+                format: '#,##0.00'
             }
         ],
         attributes: [
@@ -842,7 +866,8 @@ export const reducedMultipleSorts: IFixture = {
                         }
                     }
                 },
-                alias: 'Sum of Bundle cost'
+                alias: 'Sum of Bundle cost',
+                format: '#,##0.00'
             },
             {
                 localIdentifier: 'm2',
@@ -854,7 +879,8 @@ export const reducedMultipleSorts: IFixture = {
                         }
                     }
                 },
-                alias: 'Sum of Bundle cost'
+                alias: 'Sum of Bundle cost',
+                format: '#,##0.00'
             }
         ]
     },

--- a/src/DataLayer/converters/tests/fixtures/MeasureConverter.afm.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/MeasureConverter.afm.fixtures.ts
@@ -13,6 +13,19 @@ export const simpleMeasure: IMeasure = {
     alias: 'Measure M1'
 };
 
+export const simpleMeasureWithFormat: IMeasure = {
+    localIdentifier: 'm1',
+    definition: {
+        measure: {
+            item: {
+                uri: '/gdc/md/project/obj/metric.id'
+            }
+        }
+    },
+    alias: 'Measure M1',
+    format: 'GD #,##0.00000'
+};
+
 export const simpleMeasureWithIdentifiers: IMeasure = {
     localIdentifier: 'm1',
     definition: {

--- a/src/DataLayer/converters/tests/fixtures/MeasureConverter.visObj.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/MeasureConverter.visObj.fixtures.ts
@@ -188,7 +188,7 @@ export const factBasedRenamedMeasure: IMeasure = {
 export const attributeBasedMeasure: IMeasure = {
     measure: {
         localIdentifier: 'm1',
-        format: '#,##0',
+        format: '$#,##0.00',
         definition: {
             measureDefinition: {
                 item: {
@@ -218,7 +218,7 @@ export const attributeBasedRenamedMeasure: IMeasure = {
     measure: {
         localIdentifier: 'm1',
         alias: 'Count',
-        format: '#,##0',
+        format: '$#,##0.00',
         definition: {
             measureDefinition: {
                 item: {
@@ -234,7 +234,7 @@ export const showInPercent: IMeasure = {
     measure: {
         localIdentifier: 'm1',
         alias: 'Measure M1',
-        format: '#,##0.00%',
+        format: '$#,##0.00',
         definition: {
             measureDefinition: {
                 item: {

--- a/src/DataLayer/converters/tests/toAfmResultSpec.spec.ts
+++ b/src/DataLayer/converters/tests/toAfmResultSpec.spec.ts
@@ -1,6 +1,7 @@
 // (C) 2007-2018 GoodData Corporation
 import {
     simpleMeasure,
+    simpleMeasureWithFormat,
     simpleMeasureWithIdentifiers,
     renamedMeasure,
     filteredMeasure,
@@ -43,9 +44,9 @@ describe('toAfmResultSpec', () => {
         });
     });
 
-    it('should ignore format defined on simple measures', () => {
+    it('should convert simple measure with format', () => {
         expect(toAfmResultSpec(charts.simpleMeasureWithFormat)).toEqual({
-            ...simpleMeasure
+            ...simpleMeasureWithFormat
         });
     });
 


### PR DESCRIPTION
`8.1.1-ocetnik-doc-measure-format-2018-09-19T13-29-51-263Z`