### PR TITLE
RELATED: BB-1406 convert subtotals to nativetotals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The REST API versions in the table are just for your information as the values a
 |\>= 10.0.0|3
 |<= 9.0.1|2
 
+<a name="11.5.0"></a>
+## 2019-03-06 Version [11.5.0](https://github.com/gooddata/gooddata-js/compare/v11.4.0...v11.5.0)
+
+### Changed
+
+- `toAfmResultSpec` now converts native subtotals to `afm.nativeTotals` correctly
+
 <a name="11.4.0"></a>
 ## 2019-03-01 Version [11.4.0](https://github.com/gooddata/gooddata-js/compare/v11.3.1...v11.4.0)
 

--- a/src/DataLayer/converters/tests/fixtures/Afm.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/Afm.fixtures.ts
@@ -901,3 +901,113 @@ export const reducedMultipleSorts: IFixture = {
         ]
     }
 };
+
+export const nativeSubTotals: IFixture = {
+    afm: {
+        attributes: [
+            {
+                displayForm: {
+                    identifier: '1'
+                },
+                localIdentifier: 'a1'
+            },
+            {
+                displayForm: {
+                    identifier: '2'
+                },
+                localIdentifier: 'a2'
+            }
+        ],
+        measures: [
+            {
+                alias: 'Sum of Bundle cost',
+                definition: {
+                    measure: {
+                        aggregation: 'sum',
+                        item: {
+                            identifier: 'metric.id'
+                        }
+                    }
+                },
+                format: '#,##0.00',
+                localIdentifier: 'm1'
+            }
+        ],
+        nativeTotals: [
+            {
+                attributeIdentifiers: [],
+                measureIdentifier: 'm1'
+            },
+            {
+                attributeIdentifiers: ['a1'],
+                measureIdentifier: 'm1'
+            }
+        ]
+    },
+    resultSpec: {}
+};
+
+export const nativeSubtotalsInTwoDimensions = {
+    afm: {
+        attributes: [
+            {
+                displayForm: {
+                    identifier: '1'
+                },
+                localIdentifier: 'a1'
+            },
+            {
+                displayForm: {
+                    identifier: '2'
+                },
+                localIdentifier: 'a2'
+            },
+            {
+                displayForm: {
+                    identifier: '1'
+                },
+                localIdentifier: 'col1'
+            },
+            {
+                displayForm: {
+                    identifier: '2'
+                },
+                localIdentifier: 'col2'
+            }
+        ],
+        measures: [
+            {
+                alias: 'Sum of Bundle cost',
+                definition: {
+                    measure: {
+                        aggregation: 'sum',
+                        item: {
+                            identifier: 'metric.id'
+                        }
+                    }
+                },
+                format: '#,##0.00',
+                localIdentifier: 'm1'
+            }
+        ],
+        nativeTotals: [
+            {
+                attributeIdentifiers: [],
+                measureIdentifier: 'm1'
+            },
+            {
+                attributeIdentifiers: ['a1'],
+                measureIdentifier: 'm1'
+            },
+            {
+                attributeIdentifiers: [],
+                measureIdentifier: 'm1'
+            },
+            {
+                attributeIdentifiers: ['col1'],
+                measureIdentifier: 'm1'
+            }
+        ]
+    },
+    resultSpec: {}
+};

--- a/src/DataLayer/converters/tests/fixtures/VisObj.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/VisObj.fixtures.ts
@@ -947,6 +947,158 @@ const oneMeasureOneAttributeWithIdentifiers: VisualizationObject.IVisualizationO
     filters: []
 };
 
+const twoAttributesAndNativeSubtotals: VisualizationObject.IVisualizationObjectContent = {
+    visualizationClass: {
+        uri: 'visClassUri'
+    },
+    buckets: [
+        {
+            localIdentifier: 'measures',
+            items: [
+                {
+                    measure: {
+                        localIdentifier: 'm1',
+                        alias: 'Sum of Bundle cost',
+                        format: '#,##0.00',
+                        definition: {
+                            measureDefinition: {
+                                item: {
+                                    identifier: METRIC_IDENTIFIER
+                                },
+                                aggregation: 'sum'
+                            }
+                        }
+                    }
+                }
+            ]
+        }, {
+            localIdentifier: 'attributes',
+            items: [
+                {
+                    visualizationAttribute: {
+                        localIdentifier: 'a1',
+                        displayForm: {
+                            identifier: '1'
+                        }
+                    }
+                },
+                {
+                    visualizationAttribute: {
+                        localIdentifier: 'a2',
+                        displayForm: {
+                            identifier: '2'
+                        }
+                    }
+                }
+            ],
+            totals: [
+                {
+                    type: 'nat',
+                    measureIdentifier: 'm1',
+                    attributeIdentifier: 'a1'
+                },
+                {
+                    type: 'nat',
+                    measureIdentifier: 'm1',
+                    attributeIdentifier: 'a2'
+                }
+            ]
+        }],
+    filters: []
+};
+
+const twoDimensionsAndNativeSubtotals: VisualizationObject.IVisualizationObjectContent = {
+    visualizationClass: {
+        uri: 'visClassUri'
+    },
+    buckets: [
+        {
+            localIdentifier: 'measures',
+            items: [
+                {
+                    measure: {
+                        localIdentifier: 'm1',
+                        alias: 'Sum of Bundle cost',
+                        format: '#,##0.00',
+                        definition: {
+                            measureDefinition: {
+                                item: {
+                                    identifier: METRIC_IDENTIFIER
+                                },
+                                aggregation: 'sum'
+                            }
+                        }
+                    }
+                }
+            ]
+        }, {
+            localIdentifier: 'attributes',
+            items: [
+                {
+                    visualizationAttribute: {
+                        localIdentifier: 'a1',
+                        displayForm: {
+                            identifier: '1'
+                        }
+                    }
+                },
+                {
+                    visualizationAttribute: {
+                        localIdentifier: 'a2',
+                        displayForm: {
+                            identifier: '2'
+                        }
+                    }
+                }
+            ],
+            totals: [
+                {
+                    type: 'nat',
+                    measureIdentifier: 'm1',
+                    attributeIdentifier: 'a1'
+                },
+                {
+                    type: 'nat',
+                    measureIdentifier: 'm1',
+                    attributeIdentifier: 'a2'
+                }
+            ]
+        }, {
+            localIdentifier: 'columns',
+            items: [
+                {
+                    visualizationAttribute: {
+                        localIdentifier: 'col1',
+                        displayForm: {
+                            identifier: '1'
+                        }
+                    }
+                },
+                {
+                    visualizationAttribute: {
+                        localIdentifier: 'col2',
+                        displayForm: {
+                            identifier: '2'
+                        }
+                    }
+                }
+            ],
+            totals: [
+                {
+                    type: 'nat',
+                    measureIdentifier: 'm1',
+                    attributeIdentifier: 'col1'
+                },
+                {
+                    type: 'nat',
+                    measureIdentifier: 'm1',
+                    attributeIdentifier: 'col2'
+                }
+            ]
+        }],
+    filters: []
+};
+
 const multipleSorts: VisualizationObject.IVisualizationObjectContent = {
     visualizationClass: {
         uri: 'visClassUri'
@@ -995,7 +1147,9 @@ const multipleSorts: VisualizationObject.IVisualizationObjectContent = {
 export const tables = {
     oneMeasureOneAttribute,
     oneMeasureOneAttributeWithIdentifiers,
-    multipleSorts
+    multipleSorts,
+    twoAttributesAndNativeSubtotals,
+    twoDimensionsAndNativeSubtotals
 };
 
 export const charts = {

--- a/src/DataLayer/converters/tests/toAfmResultSpec.spec.ts
+++ b/src/DataLayer/converters/tests/toAfmResultSpec.spec.ts
@@ -25,7 +25,9 @@ import {
     dateFilterWithoutInterval,
     oneMeasureOneAttribute,
     oneMeasureOneAttributeWithIdentifiers,
-    reducedMultipleSorts
+    reducedMultipleSorts,
+    nativeSubTotals,
+    nativeSubtotalsInTwoDimensions
 } from './fixtures/Afm.fixtures';
 
 import { charts, tables } from './fixtures/VisObj.fixtures';
@@ -204,5 +206,13 @@ describe('toAfmResultSpec', () => {
         expect(toAfmResultSpec(tables.multipleSorts)).toEqual({
             ...reducedMultipleSorts
         });
+    });
+
+    it('should convert native subtotals', () => {
+        expect(toAfmResultSpec(tables.twoAttributesAndNativeSubtotals)).toEqual(nativeSubTotals);
+    });
+
+    it('should convert native subtotals from multiple dimensions', () => {
+        expect(toAfmResultSpec(tables.twoDimensionsAndNativeSubtotals)).toEqual(nativeSubtotalsInTwoDimensions);
     });
 });

--- a/src/DataLayer/converters/toAfmResultSpec.ts
+++ b/src/DataLayer/converters/toAfmResultSpec.ts
@@ -94,14 +94,32 @@ function getMeasures(buckets: VisualizationObject.IBucket[]): VisualizationObjec
     }, []);
 }
 
+function getNativeTotalAttributeIdentifiers(
+    bucket: VisualizationObject.IBucket,
+    total: VisualizationObject.IVisualizationTotal
+): string[] {
+    const attributes = bucket.items.filter(VisualizationObject.isAttribute);
+
+    const totalAttributeIndex = attributes
+        .findIndex(attribute => attribute.visualizationAttribute.localIdentifier === total.attributeIdentifier);
+
+    return attributes
+        .slice(0, totalAttributeIndex)
+        .map(attribute => attribute.visualizationAttribute.localIdentifier);
+}
+
 function convertNativeTotals(visObj: VisualizationObject.IVisualizationObjectContent): AFM.INativeTotalItem[] {
+    const nativeTotalsPerBucket = visObj.buckets.map((bucket) => {
+        const totals = bucket.totals || [];
+        const nativeTotals = totals.filter(total => total.type === 'nat');
 
-    const nativeTotals = flatMap(visObj.buckets, (bucket => bucket.totals || [])).filter(total => total.type === 'nat');
+        return nativeTotals.map(total => ({
+            measureIdentifier: total.measureIdentifier,
+            attributeIdentifiers: getNativeTotalAttributeIdentifiers(bucket, total)
+        }));
+    });
 
-    return nativeTotals.map(total => ({
-        measureIdentifier: total.measureIdentifier,
-        attributeIdentifiers: []
-    }));
+    return flatMap(nativeTotalsPerBucket);
 }
 
 function getAttributes(buckets: VisualizationObject.IBucket[]): VisualizationObject.IVisualizationAttribute[] {


### PR DESCRIPTION
Native totals now convert just to empty attributeIdentifiers. We want to specify nativeTotal for other than first attribute.
```
execution.afm.nativeTotals: [
	{attributeIdentifiers: [], measureIdentifier: 'm1'},           // grand total
	{attributeIdentifiers: ['a1'], measureIdentifier: 'm1'},       // subtotal 1
	{attributeIdentifiers: ['a1', 'a2'], measureIdentifier: 'm1'}, // subtotal 2
]
```

---

# PR checklist

- [x] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [x] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).(../blob/master/CHANGELOG.md).