### PR TITLE
RELATED: ONE-3511 Bump `@gooddata/typings` from 2.7.1 to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The REST API versions in the table are just for your information as the values a
 |\>= 10.0.0|3
 |<= 9.0.1|2
 
+<a name="11.6.0"></a>
+## 2019-03-07 Version [11.6.0](https://github.com/gooddata/gooddata-js/compare/v11.5.0...v11.6.0)
+
+- upgrade GoodData typings
+
 <a name="11.5.0"></a>
 ## 2019-03-06 Version [11.5.0](https://github.com/gooddata/gooddata-js/compare/v11.4.0...v11.5.0)
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "webpack-dev-server": "1.16.1"
   },
   "dependencies": {
-    "@gooddata/typings": "2.7.1",
+    "@gooddata/typings": "2.8.0",
     "es6-promise": "3.0.2",
     "fetch-cookie": "0.7.0",
     "invariant": "2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     tslint-eslint-rules "5.4.0"
     tslint-react "3.6.0"
 
-"@gooddata/typings@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.7.1.tgz#98aa08e81c630064e9907b40101dad0a988e082a"
-  integrity sha512-tLEGwMy/iDw9ASCwyYxnrBvzIesiYljTDO/RU2QCbjvWYCbadlY407k24wuFVvahyFxwv/eSWL2qLrE4+6y01w==
+"@gooddata/typings@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.8.0.tgz#1138172b286e040609f7fd4901de2160b5279789"
+  integrity sha512-cu+Wt+Saq4ThP2o/zV4TAfL/IoOEUjWEpCiHUPeRUnO36ijFhgQqYRb70CAnLht6KZG9f1i0eWpUXkVahAjQ4Q==
   dependencies:
     lodash "4.17.11"
 


### PR DESCRIPTION
_Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty)._

---

# PR checklist

- [x] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
 - N/A
- [x] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
 - done
- [x] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
 - N/A