### PR TITLE
RELATED: ONE-3610 Support text filters in simple measures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The REST API versions in the table are just for your information as the values a
 |<= 9.0.1|2
 
 <a name="11.7.0"></a>
+## 2019-03-27 Version [11.8.0](https://github.com/gooddata/gooddata-js/compare/v11.7.0...v11.8.0)
+
+- enhance AFM and execute-afm to support values instead of attribute element URIs in attribute filters used in
+  simple measures
+
+<a name="11.7.0"></a>
 ## 2019-03-25 Version [11.7.0](https://github.com/gooddata/gooddata-js/compare/v11.6.0...v11.7.0)
 
 - enhance AFM and execute-afm to support values instead of attribute element URIs in positive and negative attribute filters

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "webpack-dev-server": "1.16.1"
   },
   "dependencies": {
-    "@gooddata/typings": "2.9.0",
+    "@gooddata/typings": "2.10.0",
     "es6-promise": "3.0.2",
     "fetch-cookie": "0.7.0",
     "invariant": "2.2.2",

--- a/src/DataLayer/converters/tests/MeasureConverter.spec.ts
+++ b/src/DataLayer/converters/tests/MeasureConverter.spec.ts
@@ -22,6 +22,12 @@ describe('convertMeasure', () => {
         });
     });
 
+    it('should convert simple measure with filter', () => {
+        expect(MeasureConverter.convertMeasure(measures.simpleMeasureWithFilter)).toEqual({
+            ...afm.simpleMeasureWithFilter
+        });
+    });
+
     it('should convert simple renamed measures', () => {
         expect(MeasureConverter.convertMeasure(measures.renamedMeasure)).toEqual({
             ...afm.renamedMeasure

--- a/src/DataLayer/converters/tests/fixtures/Afm.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/Afm.fixtures.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import { AFM } from '@gooddata/typings';
 import { Granularities } from '../../../constants/granularities';
 
@@ -78,6 +78,34 @@ export const simpleMeasureWithIdentifiers: IFixture = {
                     }
                 },
                 alias: 'Measure M1'
+            }
+        ]
+    },
+    resultSpec: {
+    }
+};
+
+export const simpleMeasureWithTextFilter: IFixture = {
+    afm: {
+        measures: [
+            {
+                localIdentifier: 'm1',
+                definition: {
+                    measure: {
+                        item: {
+                            uri: METRIC_URI
+                        },
+                        filters: [
+                            {
+                                positiveAttributeFilter: {
+                                    displayForm: { identifier: 'foo' },
+                                    in: [ 'val1', 'val2' ],
+                                    textFilter: true
+                                }
+                            }
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -656,6 +684,38 @@ export const attributeFilter: IFixture = {
                     in: [
                         `${ATTRIBUTE_URI_2}?id=a`
                     ]
+                }
+            }
+        ]
+    },
+    resultSpec: {}
+};
+
+export const attributeTextFilter: IFixture = {
+    afm: {
+        filters: [
+            {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: ATTRIBUTE_DISPLAY_FORM_URI
+                    },
+                    in: [
+                        'val1',
+                        'val2',
+                        'val3'
+                    ],
+                    textFilter: true
+                }
+            },
+            {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: ATTRIBUTE_DISPLAY_FORM_URI_2
+                    },
+                    in: [
+                        'valA'
+                    ],
+                    textFilter: true
                 }
             }
         ]

--- a/src/DataLayer/converters/tests/fixtures/MeasureConverter.afm.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/MeasureConverter.afm.fixtures.ts
@@ -27,6 +27,26 @@ export const simpleMeasureWithFormat: IMeasure = {
     format: 'GD #,##0.00000'
 };
 
+export const simpleMeasureWithFilter: IMeasure = {
+    localIdentifier: 'm1',
+    definition: {
+        measure: {
+            item: {
+                uri: '/gdc/md/project/obj/metric.id'
+            },
+            filters: [
+                {
+                    positiveAttributeFilter: {
+                        displayForm: { identifier: 'foo' },
+                        in: [ 'val1', 'val2' ],
+                        textFilter: true
+                    }
+                }
+            ]
+        }
+    }
+};
+
 export const simpleMeasureWithIdentifiers: IMeasure = {
     localIdentifier: 'm1',
     definition: {

--- a/src/DataLayer/converters/tests/fixtures/MeasureConverter.visObj.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/MeasureConverter.visObj.fixtures.ts
@@ -45,6 +45,28 @@ export const simpleMeasureWithFormat: IMeasure = {
     }
 };
 
+export const simpleMeasureWithFilter: IMeasure = {
+    measure: {
+        localIdentifier: 'm1',
+        definition: {
+            measureDefinition: {
+                item: {
+                    uri: '/gdc/md/project/obj/metric.id'
+                },
+                filters: [
+                    {
+                        positiveAttributeFilter: {
+                            displayForm: { identifier: 'foo' },
+                            in: [ 'val1', 'val2' ],
+                            textFilter: true
+                        }
+                    }
+                ]
+            }
+        }
+    }
+};
+
 export const renamedMeasure: IMeasure = {
     measure: {
         localIdentifier: 'm1',

--- a/src/DataLayer/converters/tests/fixtures/VisObj.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/VisObj.fixtures.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import { VisualizationObject } from '@gooddata/typings';
 import {
     ATTRIBUTE_DISPLAY_FORM_URI,
@@ -79,6 +79,39 @@ const simpleMeasureWithFormat: VisualizationObject.IVisualizationObjectContent =
                                 item: {
                                     uri: '/gdc/md/project/obj/metric.id'
                                 }
+                            }
+                        }
+                    }
+                }
+            ]
+        }]
+};
+
+const simpleMeasureWithTextFilter: VisualizationObject.IVisualizationObjectContent = {
+    visualizationClass: {
+        uri: 'visClassUri'
+    },
+    buckets: [
+        {
+            localIdentifier: 'measures',
+            items: [
+                {
+                    measure: {
+                        localIdentifier: 'm1',
+                        definition: {
+                            measureDefinition: {
+                                item: {
+                                    uri: '/gdc/md/project/obj/metric.id'
+                                },
+                                filters: [
+                                    {
+                                        positiveAttributeFilter: {
+                                            displayForm: { identifier: 'foo' },
+                                            in: [ 'val1', 'val2' ],
+                                            textFilter: true
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -672,6 +705,39 @@ const attributeFilter: VisualizationObject.IVisualizationObjectContent = {
     ]
 };
 
+const attributeTextFilter: VisualizationObject.IVisualizationObjectContent = {
+    visualizationClass: {
+        uri: 'visClassUri'
+    },
+    buckets: [],
+    filters: [
+        {
+            positiveAttributeFilter: {
+                displayForm: {
+                    uri: ATTRIBUTE_DISPLAY_FORM_URI
+                },
+                in: [
+                    'val1',
+                    'val2',
+                    'val3'
+                ],
+                textFilter: true
+            }
+        },
+        {
+            positiveAttributeFilter: {
+                displayForm: {
+                    uri: ATTRIBUTE_DISPLAY_FORM_URI_2
+                },
+                in: [
+                    'valA'
+                ],
+                textFilter: true
+            }
+        }
+    ]
+};
+
 const dateFilter: VisualizationObject.IVisualizationObjectContent = {
     visualizationClass: {
         uri: 'visClassUri'
@@ -1156,6 +1222,7 @@ export const charts = {
     simpleMeasure,
     simpleMeasureWithIdentifiers,
     simpleMeasureWithFormat,
+    simpleMeasureWithTextFilter,
     renamedMeasure,
     filteredMeasure,
     measureWithRelativeDate,
@@ -1176,6 +1243,7 @@ export const charts = {
     dateFilterWithStrings,
     dateFilterWithUndefs,
     attributeFilter,
+    attributeTextFilter,
     attributeFilterWithAll,
     stackingAttribute,
     stackingRenamedAttribute

--- a/src/DataLayer/converters/tests/toAfmResultSpec.spec.ts
+++ b/src/DataLayer/converters/tests/toAfmResultSpec.spec.ts
@@ -1,8 +1,9 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import {
     simpleMeasure,
     simpleMeasureWithFormat,
     simpleMeasureWithIdentifiers,
+    simpleMeasureWithTextFilter,
     renamedMeasure,
     filteredMeasure,
     measureWithAbsoluteDate,
@@ -20,6 +21,7 @@ import {
     stackingAttribute,
     stackingRenamedAttribute,
     attributeFilter,
+    attributeTextFilter,
     attributeFilterWithAll,
     dateFilter,
     dateFilterWithoutInterval,
@@ -49,6 +51,12 @@ describe('toAfmResultSpec', () => {
     it('should convert simple measure with format', () => {
         expect(toAfmResultSpec(charts.simpleMeasureWithFormat)).toEqual({
             ...simpleMeasureWithFormat
+        });
+    });
+
+    it('should convert simple measure with text filter', () => {
+        expect(toAfmResultSpec(charts.simpleMeasureWithTextFilter)).toEqual({
+            ...simpleMeasureWithTextFilter
         });
     });
 
@@ -151,6 +159,12 @@ describe('toAfmResultSpec', () => {
     it('should convert attribute filter', () => {
         expect(toAfmResultSpec(charts.attributeFilter)).toEqual({
             ...attributeFilter
+        });
+    });
+
+    it('should convert attribute filter', () => {
+        expect(toAfmResultSpec(charts.attributeTextFilter)).toEqual({
+            ...attributeTextFilter
         });
     });
 

--- a/src/execution/execute-afm.convert.ts
+++ b/src/execution/execute-afm.convert.ts
@@ -7,25 +7,43 @@ function convertElementsArray(arr: string[], isText?: boolean): ExecuteAFM.Attri
     return isText ? { values: arr } : { uris: arr };
 }
 
+function convertPositiveAttributeFilter(filter: AFM.IPositiveAttributeFilter): ExecuteAFM.IPositiveAttributeFilter {
+    const { positiveAttributeFilter: oldFilter } = filter;
+
+    return {
+        positiveAttributeFilter: {
+            displayForm: oldFilter.displayForm,
+            in: convertElementsArray(oldFilter.in, oldFilter.textFilter)
+        }
+    };
+}
+
+function convertNegativeAttributeFilter(filter: AFM.INegativeAttributeFilter): ExecuteAFM.INegativeAttributeFilter {
+    const { negativeAttributeFilter: oldFilter } = filter;
+
+    return {
+        negativeAttributeFilter: {
+            displayForm: oldFilter.displayForm,
+            notIn: convertElementsArray(oldFilter.notIn, oldFilter.textFilter)
+        }
+    };
+}
+
 function convertFilter(filter: AFM.CompatibilityFilter): ExecuteAFM.CompatibilityFilter {
     if (AFM.isPositiveAttributeFilter(filter)) {
-        const { positiveAttributeFilter: oldFilter } = filter;
-
-        return {
-            positiveAttributeFilter: {
-                displayForm: oldFilter.displayForm,
-                in: convertElementsArray(oldFilter.in, oldFilter.textFilter)
-            }
-        };
+        return convertPositiveAttributeFilter(filter);
     } else if (AFM.isNegativeAttributeFilter(filter)) {
-        const { negativeAttributeFilter: oldFilter } = filter;
+        return convertNegativeAttributeFilter(filter);
+    }
 
-        return {
-            negativeAttributeFilter: {
-                displayForm: oldFilter.displayForm,
-                notIn: convertElementsArray(oldFilter.notIn, oldFilter.textFilter)
-            }
-        };
+    return filter;
+}
+
+function convertMeasureFilter(filter: AFM.FilterItem): ExecuteAFM.FilterItem {
+    if (AFM.isPositiveAttributeFilter(filter)) {
+        return convertPositiveAttributeFilter(filter);
+    } else if (AFM.isNegativeAttributeFilter(filter)) {
+        return convertNegativeAttributeFilter(filter);
     }
 
     return filter;
@@ -33,6 +51,34 @@ function convertFilter(filter: AFM.CompatibilityFilter): ExecuteAFM.Compatibilit
 
 function convertFilters(filters?: AFM.CompatibilityFilter[]): ExecuteAFM.CompatibilityFilter[] | undefined {
     return filters !== undefined ? filters.map(convertFilter) : filters;
+}
+
+function convertMeasureFilters(filters?: AFM.FilterItem[]): ExecuteAFM.FilterItem[] | undefined {
+    return filters !== undefined ? filters.map(convertMeasureFilter) : filters;
+}
+
+function convertMeasure(measure: AFM.IMeasure): ExecuteAFM.IMeasure {
+    if (AFM.isSimpleMeasureDefinition(measure.definition)) {
+        const simpleMeasure = measure.definition.measure;
+        const filters = convertMeasureFilters(simpleMeasure.filters);
+        const filtersProp = filters ? { filters } : {};
+
+        return {
+            ...measure,
+            definition: {
+                measure: {
+                    ...simpleMeasure,
+                    ...filtersProp
+                }
+            }
+        };
+    }
+
+    return measure;
+}
+
+function convertMeasures(measures?: AFM.IMeasure[]): ExecuteAFM.IMeasure[] | undefined {
+    return measures !== undefined ? measures.map(convertMeasure) : measures;
 }
 
 /**
@@ -48,6 +94,7 @@ export function convertAfm(afm?: AFM.IAfm): ExecuteAFM.IAfm {
 
     const executeAFM: ExecuteAFM.IAfm = {
         ...afm,
+        measures: convertMeasures(afm.measures),
         filters: convertFilters(afm.filters)
     };
 

--- a/src/execution/tests/execute-afm.convert.spec.ts
+++ b/src/execution/tests/execute-afm.convert.spec.ts
@@ -23,3 +23,23 @@ describe.each(FILTER_TESTS)('convertAfm', (desc, input, expected) => {
         expect(convertAfm({ filters: input })).toEqual({ filters: expected });
     });
 });
+
+const MEASURE_TESTS = [
+    ['convert simple measure with filters', [ input.simpleMeasureWithFilters ],
+        [ input.simpleMeasureWithFiltersExpected]],
+    ['convert simple measure with mixed filters', [ input.simpleMeasureWithMixedFilters ],
+        [ input.simpleMeasureWithMixedFiltersExpected]],
+    ['convert simple measure with empty filters', [ input.simpleMeasureWithEmptyFilters ],
+        [ input.simpleMeasureWithEmptyFiltersExpected]],
+    ['convert simple measure with undefined filters', [ input.simpleMeasureWithUndefinedFilters ],
+        [ input.simpleMeasureWithUndefinedFiltersExpected]],
+    ['leave arithmetic measure as is', [ input.arithmeticMeasure ], [ input.arithmeticMeasure ]],
+    ['leave PoP measure as is', [ input.popMeasure ], [ input.popMeasure ]],
+    ['leave previousPeriod measure as is', [ input.previousPeriodMeasure ], [ input.previousPeriodMeasure ]]
+];
+
+describe.each(MEASURE_TESTS)('convertAfm', (desc, input, expected) => {
+    it(`should ${desc}`, () => {
+        expect(convertAfm({ measures: input })).toEqual({ measures: expected });
+    });
+});

--- a/src/execution/tests/fixtures.ts
+++ b/src/execution/tests/fixtures.ts
@@ -21,14 +21,14 @@ export const absoluteDate: AFM.IAbsoluteDateFilter = {
 export const positiveUri: AFM.IPositiveAttributeFilter = {
     positiveAttributeFilter: {
         displayForm: { identifier: 'foo' },
-        in: [ 'uri1', 'uri2' ]
+        in: ['uri1', 'uri2']
     }
 };
 
 export const positiveValue: AFM.IPositiveAttributeFilter = {
     positiveAttributeFilter: {
         displayForm: { identifier: 'foo' },
-        in: [ 'val1', 'val2' ],
+        in: ['val1', 'val2'],
         textFilter: true
     }
 };
@@ -36,28 +36,28 @@ export const positiveValue: AFM.IPositiveAttributeFilter = {
 export const positiveUriExpected: ExecuteAFM.IPositiveAttributeFilter = {
     positiveAttributeFilter: {
         displayForm: { identifier: 'foo' },
-        in: { uris: [ 'uri1', 'uri2' ] }
+        in: { uris: ['uri1', 'uri2'] }
     }
 };
 
 export const positiveValueExpected: ExecuteAFM.IPositiveAttributeFilter = {
     positiveAttributeFilter: {
         displayForm: { identifier: 'foo' },
-        in: { values: [ 'val1', 'val2' ] }
+        in: { values: ['val1', 'val2'] }
     }
 };
 
 export const negativeUri: AFM.INegativeAttributeFilter = {
     negativeAttributeFilter: {
         displayForm: { identifier: 'foo' },
-        notIn: [ 'uri1', 'uri2' ]
+        notIn: ['uri1', 'uri2']
     }
 };
 
 export const negativeValue: AFM.INegativeAttributeFilter = {
     negativeAttributeFilter: {
         displayForm: { identifier: 'foo' },
-        notIn: [ 'val1', 'val2' ],
+        notIn: ['val1', 'val2'],
         textFilter: true
     }
 };
@@ -65,13 +65,228 @@ export const negativeValue: AFM.INegativeAttributeFilter = {
 export const negativeUriExpected: ExecuteAFM.INegativeAttributeFilter = {
     negativeAttributeFilter: {
         displayForm: { identifier: 'foo' },
-        notIn: { uris: [ 'uri1', 'uri2' ] }
+        notIn: { uris: ['uri1', 'uri2'] }
     }
 };
 
 export const negativeValueExpected: ExecuteAFM.INegativeAttributeFilter = {
     negativeAttributeFilter: {
         displayForm: { identifier: 'foo' },
-        notIn: { values: [ 'val1', 'val2' ] }
+        notIn: { values: ['val1', 'val2'] }
+    }
+};
+
+export const simpleMeasureWithFilters: AFM.IMeasure = {
+    localIdentifier: 'measure',
+    alias: 'test measure',
+    definition: {
+        measure: {
+            item: { uri: 'uri1' },
+            filters: [
+                {
+                    positiveAttributeFilter: {
+                        displayForm: { identifier: 'foot' },
+                        in: ['val1', 'val2'],
+                        textFilter: true
+                    }
+                },
+                {
+                    positiveAttributeFilter: {
+                        displayForm: { identifier: 'foot' },
+                        in: ['uri1', 'uri2']
+                    }
+                },
+                {
+                    negativeAttributeFilter: {
+                        displayForm: { identifier: 'foot' },
+                        notIn: ['val1', 'val2'],
+                        textFilter: true
+                    }
+                },
+                {
+                    negativeAttributeFilter: {
+                        displayForm: { identifier: 'foot' },
+                        notIn: ['uri1', 'uri2']
+                    }
+                }
+            ]
+        }
+    }
+};
+
+export const simpleMeasureWithFiltersExpected: ExecuteAFM.IMeasure = {
+    localIdentifier: 'measure',
+    alias: 'test measure',
+    definition: {
+        measure: {
+            item: { uri: 'uri1' },
+            filters: [
+                {
+                    positiveAttributeFilter: {
+                        displayForm: { identifier: 'foot' },
+                        in: { values: ['val1', 'val2'] }
+                    }
+                },
+                {
+                    positiveAttributeFilter: {
+                        displayForm: { identifier: 'foot' },
+                        in: { uris: ['uri1', 'uri2'] }
+                    }
+                },
+                {
+                    negativeAttributeFilter: {
+                        displayForm: { identifier: 'foot' },
+                        notIn: { values: ['val1', 'val2'] }
+                    }
+                },
+                {
+                    negativeAttributeFilter: {
+                        displayForm: { identifier: 'foot' },
+                        notIn: { uris: ['uri1', 'uri2'] }
+                    }
+                }
+            ]
+        }
+    }
+};
+
+export const simpleMeasureWithMixedFilters: AFM.IMeasure = {
+    localIdentifier: 'any-string',
+    definition: {
+        measure: {
+            item: {
+                uri: '/gdc/md/mockproject/obj/__won'
+            },
+            filters: [
+                {
+                    relativeDateFilter: {
+                        dataSet: {
+                            uri: '/gdc/md/mockproject/obj/activity.dataset'
+                        },
+                        granularity: 'GDC.time.year',
+                        from: -3,
+                        to: -3
+                    }
+                },
+                {
+                    positiveAttributeFilter: {
+                        displayForm: {
+                            uri: '/gdc/md/mockproject/obj/attr.checkbox.df'
+                        },
+                        in: [
+                            '/gdc/md/mockproject/obj/attr.checkbox/elements?id=0',
+                            '/gdc/md/mockproject/obj/attr.checkbox/elements?id=1'
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    alias: 'alias'
+};
+
+export const simpleMeasureWithMixedFiltersExpected: ExecuteAFM.IMeasure = {
+    localIdentifier: 'any-string',
+    definition: {
+        measure: {
+            item: {
+                uri: '/gdc/md/mockproject/obj/__won'
+            },
+            filters: [
+                {
+                    relativeDateFilter: {
+                        dataSet: {
+                            uri: '/gdc/md/mockproject/obj/activity.dataset'
+                        },
+                        granularity: 'GDC.time.year',
+                        from: -3,
+                        to: -3
+                    }
+                },
+                {
+                    positiveAttributeFilter: {
+                        displayForm: {
+                            uri: '/gdc/md/mockproject/obj/attr.checkbox.df'
+                        },
+                        in: {
+                            uris: [
+                                '/gdc/md/mockproject/obj/attr.checkbox/elements?id=0',
+                                '/gdc/md/mockproject/obj/attr.checkbox/elements?id=1'
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    alias: 'alias'
+};
+
+export const simpleMeasureWithEmptyFilters: AFM.IMeasure = {
+    localIdentifier: 'measure',
+    definition: {
+        measure: {
+            item: { uri: 'uri1' },
+            filters: []
+        }
+    }
+};
+
+export const simpleMeasureWithEmptyFiltersExpected: ExecuteAFM.IMeasure = {
+    localIdentifier: 'measure',
+    definition: {
+        measure: {
+            item: { uri: 'uri1' },
+            filters: []
+        }
+    }
+};
+
+export const simpleMeasureWithUndefinedFilters: AFM.IMeasure = {
+    localIdentifier: 'measure',
+    definition: {
+        measure: {
+            item: { uri: 'uri1' },
+            filters: undefined
+        }
+    }
+};
+
+export const simpleMeasureWithUndefinedFiltersExpected: ExecuteAFM.IMeasure = {
+    localIdentifier: 'measure',
+    definition: {
+        measure: {
+            item: { uri: 'uri1' }
+        }
+    }
+};
+
+export const arithmeticMeasure: AFM.IMeasure = {
+    localIdentifier: 'measure',
+    definition: {
+        arithmeticMeasure: {
+            operator: 'change',
+            measureIdentifiers: ['m1', 'm2']
+        }
+    }
+};
+
+export const popMeasure: AFM.IMeasure = {
+    localIdentifier: 'measure',
+    definition: {
+        popMeasure: {
+            popAttribute: { identifier: 'foo' },
+            measureIdentifier: 'm1'
+        }
+    }
+};
+
+export const previousPeriodMeasure: AFM.IMeasure = {
+    localIdentifier: 'measure',
+    definition: {
+        previousPeriodMeasure: {
+            dateDataSets: [{ dataSet: { identifier: 'foo' }, periodsAgo: 1 }],
+            measureIdentifier: 'm1'
+        }
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,10 +139,10 @@
     tslint-eslint-rules "5.4.0"
     tslint-react "3.6.0"
 
-"@gooddata/typings@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.9.0.tgz#9ce6497aa867542768c88041d1f4cf0320adf45f"
-  integrity sha512-8s644Jcfl7j03GHBItrgEOKAjo/KpVN8SP7pBw7zwH1aPxYq9THMvpBhRlKw6UewOzGIZb3ocudkx4I7mytU4w==
+"@gooddata/typings@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.10.0.tgz#7ce8ccaabb4125af8af8a1db07c5a95a5de12a65"
+  integrity sha512-5A+4X1e7M18PppAzUcSsPAR2mvdEwqLB6jfldL0a97d0Mabgp4S1/cFPbGDNh6pqeCEASugE2Zcl070ObtEHGg==
   dependencies:
     lodash "4.17.11"
 


### PR DESCRIPTION
This PR completes previously started work on text filters:

- It ensures that simple measures have their filters correctly transformed from AFM to ExecuteAFM format, reflecting the definition of textFilter value

---

# PR checklist

- [x] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [x] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).