### PR TITLE
RELATED: ONE-3955 Experimental support of executeVisualization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: yarn
 dist: trusty
 
 node_js:
-  - "6"
   - "8"
 
 script: yarn test-ci

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -15,6 +15,10 @@ import { MetadataModule } from "./metadata";
 export class ExecutionModule {
     public readonly executeAfm: ExecuteAfmModule["executeAfm"];
     public readonly getExecutionResponse: ExecuteAfmModule["getExecutionResponse"];
+
+    public readonly _executeVisualization: ExecuteAfmModule["_executeVisualization"];
+    public readonly _getVisExecutionResponse: ExecuteAfmModule["_getVisExecutionResponse"];
+
     public readonly getPartialExecutionResult: ExecuteAfmModule["getPartialExecutionResult"];
     public readonly getExecutionResult: ExecuteAfmModule["getExecutionResult"];
     private readonly executeAfmModule: ExecuteAfmModule;
@@ -25,6 +29,10 @@ export class ExecutionModule {
         this.executeAfmModule = new ExecuteAfmModule(xhr);
         this.executeAfm = this.executeAfmModule.executeAfm.bind(this.executeAfmModule);
         this.getExecutionResponse = this.executeAfmModule.getExecutionResponse.bind(this.executeAfmModule);
+        this._executeVisualization = this.executeAfmModule._executeVisualization.bind(this.executeAfmModule);
+        this._getVisExecutionResponse = this.executeAfmModule._getVisExecutionResponse.bind(
+            this.executeAfmModule,
+        );
         this.getPartialExecutionResult = this.executeAfmModule.getPartialExecutionResult.bind(
             this.executeAfmModule,
         );


### PR DESCRIPTION
This PR delivers minimum infrastructure needed to support experimental data sources that use the `executeVisualization` backend instead of `executeAfm` when rendering visualization by URI:

ExecuteVisualization backend allows to pass URI + filters + resultSpec; given these, it automatically constructs AFM and calls the executeAfm logic; the execution response and results and everything else from that point on remains the same as with executeAfm. Code related to fiddling with the results can be thus reused as-is.

- ExecuteAfmModule now contains _executeVisualization and _getVisExecutionResponse methods
- The new methods will be 'annotated' and documented as experimental and not part of the gooddata-js public API just yet

The newly introduced methods will be made public once we adopt their use in KD. For now, they will be used in an experimental fashion in the Visualization URI component in SDK (new functions will be used based on value of a prop)

---

# PR checklist

- [ ] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [ ] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).

# Related PRs:

https://github.com/gooddata/gdc-analytical-designer/pull/2405
https://github.com/gooddata/gdc-dashboards/pull/2189