### PR TITLE
RELATED: RAIL-1719 make adapters projectId public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The REST API versions in the table are just for your information as the values a
 |\>= 10.0.0|3
 |<= 9.0.1|2
 
+<a name="11.18.1"></a>
+## 2019-08-27 Version [11.18.1](https://github.com/gooddata/gooddata-js/compare/v11.18.0...v11.18.1)
+
+- make ExecuteAfmAdapter projectId property public
+
 <a name="11.18.0"></a>
 ## 2019-08-12 Version [11.18.0](https://github.com/gooddata/gooddata-js/compare/v11.17.0...v11.18.0)
 

--- a/src/DataLayer/adapters/ExecuteAfmAdapter.ts
+++ b/src/DataLayer/adapters/ExecuteAfmAdapter.ts
@@ -9,7 +9,7 @@ import { version as pkgVersion } from "../../../package.json";
 export class ExecuteAfmAdapter implements IAdapter<Execution.IExecutionResponses> {
     private sdk: SDK;
 
-    constructor(sdk: SDK, private projectId: string) {
+    constructor(sdk: SDK, public projectId: string) {
         this.sdk = sdk.clone();
         this.sdk.config.setJsPackage("@gooddata/data-layer", pkgVersion);
     }


### PR DESCRIPTION
We need to be able to change it ex post in some cases.

# PR checklist

- [x] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [x] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).