### PR TITLE
BUGFIX: SD-825 Attribute name in tooltip isn't updated after renaming

### DIFF
--- a/src/DataLayer/constants/buckets.ts
+++ b/src/DataLayer/constants/buckets.ts
@@ -1,2 +1,3 @@
 // (C) 2020 GoodData Corporation
 export const TOOLTIP_TEXT = "tooltipText";
+export const LOCATION = "location";

--- a/src/DataLayer/converters/tests/fixtures/VisObj.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/VisObj.fixtures.ts
@@ -1373,7 +1373,7 @@ export const visualizationObjectWithLocationAttribute: VisualizationObject.IVisu
     },
     buckets: [
         {
-            localIdentifier: "locaiton",
+            localIdentifier: "location",
             items: [
                 {
                     visualizationAttribute: {
@@ -1381,6 +1381,29 @@ export const visualizationObjectWithLocationAttribute: VisualizationObject.IVisu
                         displayForm: {
                             uri: "/gdc/md/pid/obj/87",
                         },
+                    },
+                },
+            ],
+        },
+    ],
+    properties: '{"controls":{"tooltipText":"/gdc/md/pid/obj/88"}}',
+};
+
+export const visualizationObjectWithLocationAliasAttribute: VisualizationObject.IVisualizationObjectContent = {
+    visualizationClass: {
+        uri: "visClassUri",
+    },
+    buckets: [
+        {
+            localIdentifier: "location",
+            items: [
+                {
+                    visualizationAttribute: {
+                        localIdentifier: "a1",
+                        displayForm: {
+                            uri: "/gdc/md/pid/obj/87",
+                        },
+                        alias: "location alias",
                     },
                 },
             ],

--- a/src/DataLayer/converters/tests/toAfmResultSpec.spec.ts
+++ b/src/DataLayer/converters/tests/toAfmResultSpec.spec.ts
@@ -34,7 +34,12 @@ import {
     nativeSubtotalsInTwoDimensions,
 } from "./fixtures/Afm.fixtures";
 
-import { charts, tables, visualizationObjectWithLocationAttribute } from "./fixtures/VisObj.fixtures";
+import {
+    charts,
+    tables,
+    visualizationObjectWithLocationAttribute,
+    visualizationObjectWithLocationAliasAttribute,
+} from "./fixtures/VisObj.fixtures";
 import { toAfmResultSpec } from "../toAfmResultSpec";
 
 describe("toAfmResultSpec", () => {
@@ -256,6 +261,23 @@ describe("toAfmResultSpec", () => {
                 {
                     displayForm: { uri: "/gdc/md/pid/obj/88" },
                     localIdentifier: "tooltipText",
+                },
+            ],
+        });
+    });
+
+    it("should convert geo attribute for tooltip text with alias", () => {
+        expect(toAfmResultSpec(visualizationObjectWithLocationAliasAttribute).afm).toEqual({
+            attributes: [
+                {
+                    displayForm: { uri: "/gdc/md/pid/obj/87" },
+                    localIdentifier: "a1",
+                    alias: "location alias",
+                },
+                {
+                    displayForm: { uri: "/gdc/md/pid/obj/88" },
+                    localIdentifier: "tooltipText",
+                    alias: "location alias",
                 },
             ],
         });


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

<!--
 Choose one of the three release types this change will be released as.
 When a change MUST be major:
 * backwards incompatible change in functionality - this includes:
   * removing/changing the order of parameters in a public function
   * removing/renaming a public module
 * backwards incompatible change in TypeScript types - this includes:
   * changing a type of a function parameters/return type to an incompatible type (e.g. number to string; number to number | string is fine)
 * major upgrade of ANY dependency
 * minor upgrade of typescript
 * changes in build logic that could make the output incompatible
 -->

**Proposed release type:** patch

# PR checklist

- [x] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [ ] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] The proposed release type is appropriate (see the comment in [PR template](../blob/master/.github/pull_request_template.md))

# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2874
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2613

# Related Jira tasks
- SD-825: https://jira.intgdc.com/browse/SD-825