### PR TITLE
BUGFIX: RAIL-2138, RAIL-2131 Fix saveAs button problem with old dashboards without layout and update date in meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The REST API versions in the table are just for your information as the values a
 |\>= 10.0.0|3
 |<= 9.0.1|2
 
+<a name="12.5.2"></a>
+## 2020-03-26 Version [12.5.2](https://github.com/gooddata/gooddata-js/compare/v12.5.2...v12.5.1)
+
+- fix saveAs function problem with saving old dashboards without layout
+- fix saveAs function problem with saving new update date in meta
+
 <a name="12.2.0"></a>
 ## 2020-01-21 Version [12.2.0](https://github.com/gooddata/gooddata-js/compare/v12.1.0...v12.2.0)
 

--- a/src/metadataExt.ts
+++ b/src/metadataExt.ts
@@ -4,6 +4,7 @@ import { XhrModule } from "./xhr";
 import { UserModule } from "./user";
 import cloneDeepWith from "lodash/cloneDeepWith";
 import isEmpty from "lodash/isEmpty";
+import omit from "lodash/omit";
 import {
     IKPI,
     IAnalyticalDashboardContent,
@@ -130,7 +131,14 @@ export class MetadataModuleExt {
                     ...dashboardDetails.analyticalDashboard,
                     content: this.getDashboardDetailObject(updatedContent, filterContext),
                     meta: {
-                        ...dashboardDetails.analyticalDashboard.meta,
+                        ...omit(dashboardDetails.analyticalDashboard.meta, [
+                            "identifier",
+                            "uri",
+                            "author",
+                            "created",
+                            "updated",
+                            "contributor",
+                        ]),
                         title: dashboardTitle,
                     },
                 },
@@ -187,14 +195,12 @@ export class MetadataModuleExt {
         updatedContent: IAnalyticalDashboardContent,
         filterContext: string,
     ): IAnalyticalDashboardContent {
-        if (isEmpty(updatedContent.layout)) {
-            return { ...updatedContent, filterContext, widgets: [...updatedContent.widgets] };
-        }
+        const { layout } = updatedContent;
         return {
             ...updatedContent,
             filterContext,
-            layout: updatedContent.layout,
             widgets: [...updatedContent.widgets],
+            ...(isEmpty(layout) ? {} : { layout }),
         };
     }
 

--- a/src/metadataExt.ts
+++ b/src/metadataExt.ts
@@ -3,6 +3,7 @@ import { MetadataModule } from "./metadata";
 import { XhrModule } from "./xhr";
 import { UserModule } from "./user";
 import cloneDeepWith from "lodash/cloneDeepWith";
+import isEmpty from "lodash/isEmpty";
 import {
     IKPI,
     IAnalyticalDashboardContent,
@@ -123,15 +124,11 @@ export class MetadataModuleExt {
             const translator = createTranslator(kpiMap, visWidgetMap);
             const updatedContent = updateContent(analyticalDashboard, translator, filterContext);
             const dashboardTitle = this.getDashboardName(analyticalDashboard.meta.title, options.name);
-            const duplicateDashboard: IAnalyticalDashboard = {
+            const duplicateDashboard = {
                 ...dashboardDetails,
                 analyticalDashboard: {
                     ...dashboardDetails.analyticalDashboard,
-                    content: {
-                        filterContext,
-                        layout: { ...updatedContent.layout },
-                        widgets: [...updatedContent.widgets],
-                    },
+                    content: this.getDashboardDetailObject(updatedContent, filterContext),
                     meta: {
                         ...dashboardDetails.analyticalDashboard.meta,
                         title: dashboardTitle,
@@ -184,6 +181,21 @@ export class MetadataModuleExt {
                 },
             },
         });
+    }
+
+    private getDashboardDetailObject(
+        updatedContent: IAnalyticalDashboardContent,
+        filterContext: string,
+    ): IAnalyticalDashboardContent {
+        if (isEmpty(updatedContent.layout)) {
+            return { ...updatedContent, filterContext, widgets: [...updatedContent.widgets] };
+        }
+        return {
+            ...updatedContent,
+            filterContext,
+            layout: updatedContent.layout,
+            widgets: [...updatedContent.widgets],
+        };
     }
 
     private getDashboardName(originalName: string, newName?: string): string {


### PR DESCRIPTION
<!--
 Choose one of the three release types this change will be released as.
 When a change MUST be major:
 * backwards incompatible change in functionality - this includes:
   * removing/changing the order of parameters in a public function
   * removing/renaming a public module
 * backwards incompatible change in TypeScript types - this includes:
   * changing a type of a function parameters/return type to an incompatible type (e.g. number to string; number to number | string is fine)
 * major upgrade of ANY dependency
 * minor upgrade of typescript
 * changes in build logic that could make the output incompatible
 -->

**Proposed release type:** patch
(https://semver.org/#semantic-versioning-specification-semver))

# PR checklist

- [x] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [x] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] The proposed release type is appropriate (see the comment in [PR template](../blob/master/.github/pull_request_template.md))

# Related PRs

- gdc-dashboards:  https://github.com/gooddata/gdc-dashboards/pull/2649
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2926