### PR TITLE
FEATURE: BB-2259 Respect custom measure format in toAfmResultSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The REST API versions in the table are just for your information as the values a
 |\>= 10.0.0|3
 |<= 9.0.1|2
 
+<a name="13.0.0"></a>
+## 2020-05-07 Version [13.0.0](https://github.com/gooddata/gooddata-js/compare/v12.5.4...v13.0.0)
+
+- Fix toAfmResultSpec to prefer custom measure format from visualization object over default formats
+
 <a name="12.5.4"></a>
 ## 2020-04-21 Version [12.5.4](https://github.com/gooddata/gooddata-js/compare/v12.5.3...v12.5.4)
 

--- a/src/DataLayer/converters/tests/MeasureConverter.spec.ts
+++ b/src/DataLayer/converters/tests/MeasureConverter.spec.ts
@@ -1,145 +1,41 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import * as measures from "./fixtures/MeasureConverter.visObj.fixtures";
 import * as afm from "./fixtures/MeasureConverter.afm.fixtures";
 import MeasureConverter from "../MeasureConverter";
+import { VisualizationObject } from "@gooddata/typings";
+import IMeasure = VisualizationObject.IMeasure;
+
+function addFormat(measure: IMeasure) {
+    return {
+        measure: {
+            ...measure.measure,
+            format: "$#,##0 custom",
+        },
+    };
+}
 
 describe("convertMeasure", () => {
-    it("should convert simple measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.simpleMeasure)).toEqual({
-            ...afm.simpleMeasure,
-        });
-    });
-
-    it("should convert simple measures with identifiers", () => {
-        expect(MeasureConverter.convertMeasure(measures.simpleMeasureWithIdentifiers)).toEqual({
-            ...afm.simpleMeasureWithIdentifiers,
-        });
-    });
-
-    it("should convert simple measure with format", () => {
-        expect(MeasureConverter.convertMeasure(measures.simpleMeasureWithFormat)).toEqual({
-            ...afm.simpleMeasureWithFormat,
-        });
-    });
-
-    it("should convert simple measure with filter", () => {
-        expect(MeasureConverter.convertMeasure(measures.simpleMeasureWithFilter)).toEqual({
-            ...afm.simpleMeasureWithFilter,
-        });
-    });
-
-    it("should convert simple renamed measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.renamedMeasure)).toEqual({
-            ...afm.renamedMeasure,
-        });
-    });
-
-    it("should convert filtered measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.filteredMeasure)).toEqual({
-            ...afm.filteredMeasure,
-        });
-    });
-
-    it("should convert relative date filtered measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.measureWithRelativeDate)).toEqual({
-            ...afm.measureWithRelativeDate,
-        });
-    });
-
-    it("should convert absolute date filtered measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.measureWithAbsoluteDate)).toEqual({
-            ...afm.measureWithAbsoluteDate,
-        });
-    });
-
-    it("should convert fact based measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.factBasedMeasure)).toEqual({
-            ...afm.factBasedMeasure,
-        });
-    });
-
-    it("should convert fact based renamed measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.factBasedRenamedMeasure)).toEqual({
-            ...afm.factBasedRenamedMeasure,
-        });
-    });
-
-    it("should convert attribute based measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.attributeBasedMeasure)).toEqual({
-            ...afm.attributeBasedMeasure,
-        });
-    });
-
-    it("should convert attribute based measures without format", () => {
-        expect(MeasureConverter.convertMeasure(measures.attributeBasedMeasureWithoutFormat)).toEqual({
-            ...afm.attributeBasedMeasure,
-        });
-    });
-
-    it("should convert attribute based renamed measures", () => {
-        expect(MeasureConverter.convertMeasure(measures.attributeBasedRenamedMeasure)).toEqual({
-            ...afm.attributeBasedRenamedMeasure,
-        });
-    });
-
-    it("should convert measure with show in percent", () => {
-        expect(MeasureConverter.convertMeasure(measures.showInPercent)).toEqual({
-            ...afm.showInPercent,
-        });
-    });
-
-    it("should convert measure with show in percent without format", () => {
-        expect(MeasureConverter.convertMeasure(measures.showInPercentWithoutFormat)).toEqual({
-            ...afm.showInPercent,
-        });
-    });
-
-    it("should convert pop measure", () => {
-        expect(MeasureConverter.convertMeasure(measures.popMeasure)).toEqual({
-            ...afm.popMeasure,
-        });
-    });
-
-    it("should convert previous period measure", () => {
-        expect(MeasureConverter.convertMeasure(measures.previousPeriodMeasure)).toEqual({
-            ...afm.previousPeriodMeasure,
-        });
-    });
-
-    it("should convert arithmetic measure", () => {
-        const arithmeticMeasure = measures.buildArithmeticMeasure(
-            "arithmetic_measure_1",
-            {},
-            "Sum of m1 and m2",
-        );
-        expect(MeasureConverter.convertMeasure(arithmeticMeasure)).toEqual({
-            ...afm.arithmeticMeasure,
-        });
-    });
-
-    it("should convert arithmetic without modification to the original object", () => {
-        const arithmeticMeasure = measures.buildArithmeticMeasure(
-            "arithmetic_measure_1",
-            {},
-            "Sum of m1 and m2",
-        );
-        expect(MeasureConverter.convertMeasure(arithmeticMeasure)).toEqual({
-            ...afm.arithmeticMeasure,
-        });
-        expect(MeasureConverter.convertMeasure(arithmeticMeasure)).toEqual({
-            ...afm.arithmeticMeasure,
-        });
-    });
-
-    describe("getFormat", () => {
-        it("should return default format for arithmetic measure sum operation", () => {
-            const arithmeticMeasure = measures.buildArithmeticMeasure("am1", { operator: "sum" });
-            expect(MeasureConverter.getFormat(arithmeticMeasure)).toBeUndefined();
-        });
-
-        it("should return percentage format for change operation", () => {
-            const arithmeticMeasure = measures.buildArithmeticMeasure("am1", { operator: "change" });
-            expect(MeasureConverter.getFormat(arithmeticMeasure)).toEqual("#,##0.00%");
-        });
+    it.each`
+        testCase                                                 | inputVizObjMeasure                             | outputAfmMeasure
+        ${"simple measures defined by URI"}                      | ${measures.simpleMeasureWithUri}               | ${afm.simpleMeasureWithUri}
+        ${"simple measure defined by identifier"}                | ${measures.simpleMeasureWithIdentifiers}       | ${afm.simpleMeasureWithIdentifiers}
+        ${"simple measure, keeping custom format"}               | ${addFormat(measures.simpleMeasureWithUri)}    | ${afm.simpleMeasureWithFormat}
+        ${"measure with filters"}                                | ${measures.measureWithFilters}                 | ${afm.measureWithFilters}
+        ${"renamed measure"}                                     | ${measures.renamedMeasure}                     | ${afm.renamedMeasure}
+        ${"fact-based measure, not adding default format"}       | ${measures.factBasedMeasure}                   | ${afm.factBasedMeasure}
+        ${"fact-based measure, keeping custom format"}           | ${addFormat(measures.factBasedMeasure)}        | ${afm.factBasedMeasureWithCustomFormat}
+        ${"attribute-based measure, adding default format"}      | ${measures.attributeBasedMeasure}              | ${afm.attributeBasedMeasure}
+        ${"attribute-based measure, keeping custom format"}      | ${addFormat(measures.attributeBasedMeasure)}   | ${afm.attributeBasedMeasureWithCustomFormat}
+        ${"POP measure, not adding default format"}              | ${measures.popMeasure}                         | ${afm.popMeasure}
+        ${"POP measure, keeping default format"}                 | ${addFormat(measures.popMeasure)}              | ${afm.popMeasureWithCustomFormat}
+        ${"previous period measure, not adding default format"}  | ${measures.previousPeriodMeasure}              | ${afm.previousPeriodMeasure}
+        ${"measure with show in percent, adding default format"} | ${measures.showInPercentMeasure}               | ${afm.showInPercentMeasure}
+        ${"measure with show in percent, keeping custom format"} | ${addFormat(measures.showInPercentMeasure)}    | ${afm.showInPercentWithCustomFormat}
+        ${"arithmetic measure, not adding default format"}       | ${measures.arithmeticMeasure}                  | ${afm.arithmeticMeasure}
+        ${"arithmetic measure, keeping custom format"}           | ${addFormat(measures.arithmeticMeasure)}       | ${afm.arithmeticMeasureWithCustomFormat}
+        ${"arithmetic measure-change, adding default format"}    | ${measures.arithmeticMeasureChange}            | ${afm.arithmeticMeasureChange}
+        ${"arithmetic measure-change, keeping custom format"}    | ${addFormat(measures.arithmeticMeasureChange)} | ${afm.arithmeticMeasureWithChangeOperatorAndCustomFormat}
+    `(`should convert $testCase`, ({ inputVizObjMeasure, outputAfmMeasure }) => {
+        expect(MeasureConverter.convertMeasure(inputVizObjMeasure)).toEqual(outputAfmMeasure);
     });
 });

--- a/src/DataLayer/converters/tests/fixtures/MeasureConverter.afm.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/MeasureConverter.afm.fixtures.ts
@@ -1,13 +1,25 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { AFM } from "@gooddata/typings";
 import IMeasure = AFM.IMeasure;
 
-export const simpleMeasure: IMeasure = {
+export const simpleMeasureWithUri: IMeasure = {
     localIdentifier: "m1",
     definition: {
         measure: {
             item: {
                 uri: "/gdc/md/project/obj/metric.id",
+            },
+        },
+    },
+    alias: "Measure M1",
+};
+
+export const simpleMeasureWithIdentifiers: IMeasure = {
+    localIdentifier: "m1",
+    definition: {
+        measure: {
+            item: {
+                identifier: "metric.id",
             },
         },
     },
@@ -24,39 +36,7 @@ export const simpleMeasureWithFormat: IMeasure = {
         },
     },
     alias: "Measure M1",
-    format: "GD #,##0.00000",
-};
-
-export const simpleMeasureWithFilter: IMeasure = {
-    localIdentifier: "m1",
-    definition: {
-        measure: {
-            item: {
-                uri: "/gdc/md/project/obj/metric.id",
-            },
-            filters: [
-                {
-                    positiveAttributeFilter: {
-                        displayForm: { identifier: "foo" },
-                        in: ["val1", "val2"],
-                        textFilter: true,
-                    },
-                },
-            ],
-        },
-    },
-};
-
-export const simpleMeasureWithIdentifiers: IMeasure = {
-    localIdentifier: "m1",
-    definition: {
-        measure: {
-            item: {
-                identifier: "metric.id",
-            },
-        },
-    },
-    alias: "Measure M1",
+    format: "$#,##0 custom",
 };
 
 export const renamedMeasure: IMeasure = {
@@ -71,7 +51,7 @@ export const renamedMeasure: IMeasure = {
     alias: "Alias A1",
 };
 
-export const filteredMeasure: IMeasure = {
+export const measureWithFilters: IMeasure = {
     localIdentifier: "m1",
     definition: {
         measure: {
@@ -80,27 +60,14 @@ export const filteredMeasure: IMeasure = {
             },
             filters: [
                 {
-                    positiveAttributeFilter: {
-                        displayForm: {
-                            uri: "/gdc/md/project/obj/1",
+                    absoluteDateFilter: {
+                        dataSet: {
+                            uri: "/gdc/md/project/333",
                         },
-                        in: ["/gdc/md/project/obj/11?id=1", "/gdc/md/project/obj/11?id=2"],
+                        from: "2016-01-01",
+                        to: "2017-01-01",
                     },
                 },
-            ],
-        },
-    },
-    alias: "Measure M1",
-};
-
-export const measureWithRelativeDate: IMeasure = {
-    localIdentifier: "m1",
-    definition: {
-        measure: {
-            item: {
-                uri: "/gdc/md/project/obj/metric.id",
-            },
-            filters: [
                 {
                     relativeDateFilter: {
                         dataSet: {
@@ -125,40 +92,23 @@ export const measureWithRelativeDate: IMeasure = {
     alias: "Measure M1",
 };
 
-export const measureWithAbsoluteDate: IMeasure = {
+export const showInPercentMeasure: IMeasure = {
     localIdentifier: "m1",
+    format: "#,##0.00%",
     definition: {
         measure: {
             item: {
                 uri: "/gdc/md/project/obj/metric.id",
             },
-            filters: [
-                {
-                    absoluteDateFilter: {
-                        dataSet: {
-                            uri: "/gdc/md/project/333",
-                        },
-                        from: "2016-01-01",
-                        to: "2017-01-01",
-                    },
-                },
-                {
-                    positiveAttributeFilter: {
-                        displayForm: {
-                            uri: "/gdc/md/project/obj/1",
-                        },
-                        in: ["/gdc/md/project/obj/11?id=1", "/gdc/md/project/obj/11?id=2"],
-                    },
-                },
-            ],
+            computeRatio: true,
         },
     },
     alias: "Measure M1",
 };
 
-export const showInPercent: IMeasure = {
+export const showInPercentWithCustomFormat: IMeasure = {
     localIdentifier: "m1",
-    format: "#,##0.00%",
+    format: "$#,##0 custom",
     definition: {
         measure: {
             item: {
@@ -182,7 +132,7 @@ export const factBasedMeasure: IMeasure = {
     },
 };
 
-export const factBasedRenamedMeasure: IMeasure = {
+export const factBasedMeasureWithCustomFormat: IMeasure = {
     localIdentifier: "m1",
     definition: {
         measure: {
@@ -192,7 +142,7 @@ export const factBasedRenamedMeasure: IMeasure = {
             aggregation: "sum",
         },
     },
-    alias: "Summary",
+    format: "$#,##0 custom",
 };
 
 export const attributeBasedMeasure: IMeasure = {
@@ -208,7 +158,7 @@ export const attributeBasedMeasure: IMeasure = {
     format: "#,##0",
 };
 
-export const attributeBasedRenamedMeasure: IMeasure = {
+export const attributeBasedMeasureWithCustomFormat: IMeasure = {
     localIdentifier: "m1",
     definition: {
         measure: {
@@ -218,8 +168,7 @@ export const attributeBasedRenamedMeasure: IMeasure = {
             aggregation: "count",
         },
     },
-    alias: "Count",
-    format: "#,##0",
+    format: "$#,##0 custom",
 };
 
 export const popMeasure: IMeasure = {
@@ -233,6 +182,20 @@ export const popMeasure: IMeasure = {
         },
     },
     alias: "Measure M1 - SP year ago",
+};
+
+export const popMeasureWithCustomFormat: IMeasure = {
+    localIdentifier: "m1_pop",
+    definition: {
+        popMeasure: {
+            measureIdentifier: "m1",
+            popAttribute: {
+                uri: "/gdc/md/project/obj/11",
+            },
+        },
+    },
+    alias: "Measure M1 - SP year ago",
+    format: "$#,##0 custom",
 };
 
 export const previousPeriodMeasure: IMeasure = {
@@ -266,6 +229,42 @@ export const arithmeticMeasure: IMeasure = {
         arithmeticMeasure: {
             measureIdentifiers: ["m1", "m2"],
             operator: "sum",
+        },
+    },
+};
+
+export const arithmeticMeasureWithCustomFormat: IMeasure = {
+    localIdentifier: "arithmetic_measure_1",
+    alias: "Sum of m1 and m2",
+    definition: {
+        arithmeticMeasure: {
+            measureIdentifiers: ["m1", "m2"],
+            operator: "sum",
+        },
+    },
+    format: "$#,##0 custom",
+};
+
+export const arithmeticMeasureChange: IMeasure = {
+    localIdentifier: "arithmetic_measure_1",
+    alias: "Sum of m1 and m2",
+    format: "#,##0.00%",
+    definition: {
+        arithmeticMeasure: {
+            measureIdentifiers: ["m1", "m2"],
+            operator: "change",
+        },
+    },
+};
+
+export const arithmeticMeasureWithChangeOperatorAndCustomFormat: IMeasure = {
+    localIdentifier: "arithmetic_measure_1",
+    alias: "Sum of m1 and m2",
+    format: "$#,##0 custom",
+    definition: {
+        arithmeticMeasure: {
+            measureIdentifiers: ["m1", "m2"],
+            operator: "change",
         },
     },
 };

--- a/src/DataLayer/converters/tests/fixtures/MeasureConverter.visObj.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/MeasureConverter.visObj.fixtures.ts
@@ -1,8 +1,8 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { VisualizationObject } from "@gooddata/typings";
 import IMeasure = VisualizationObject.IMeasure;
 
-export const simpleMeasure: IMeasure = {
+export const simpleMeasureWithUri: IMeasure = {
     measure: {
         localIdentifier: "m1",
         alias: "Measure M1",
@@ -30,43 +30,6 @@ export const simpleMeasureWithIdentifiers: IMeasure = {
     },
 };
 
-export const simpleMeasureWithFormat: IMeasure = {
-    measure: {
-        localIdentifier: "m1",
-        alias: "Measure M1",
-        format: "GD #,##0.00000",
-        definition: {
-            measureDefinition: {
-                item: {
-                    uri: "/gdc/md/project/obj/metric.id",
-                },
-            },
-        },
-    },
-};
-
-export const simpleMeasureWithFilter: IMeasure = {
-    measure: {
-        localIdentifier: "m1",
-        definition: {
-            measureDefinition: {
-                item: {
-                    uri: "/gdc/md/project/obj/metric.id",
-                },
-                filters: [
-                    {
-                        positiveAttributeFilter: {
-                            displayForm: { identifier: "foo" },
-                            in: ["val1", "val2"],
-                            textFilter: true,
-                        },
-                    },
-                ],
-            },
-        },
-    },
-};
-
 export const renamedMeasure: IMeasure = {
     measure: {
         localIdentifier: "m1",
@@ -81,65 +44,7 @@ export const renamedMeasure: IMeasure = {
     },
 };
 
-export const filteredMeasure: IMeasure = {
-    measure: {
-        localIdentifier: "m1",
-        alias: "Measure M1",
-        definition: {
-            measureDefinition: {
-                item: {
-                    uri: "/gdc/md/project/obj/metric.id",
-                },
-                filters: [
-                    {
-                        positiveAttributeFilter: {
-                            displayForm: {
-                                uri: "/gdc/md/project/obj/1",
-                            },
-                            in: [`${"/gdc/md/project/obj/11"}?id=1`, `${"/gdc/md/project/obj/11"}?id=2`],
-                        },
-                    },
-                ],
-            },
-        },
-    },
-};
-
-export const measureWithRelativeDate: IMeasure = {
-    measure: {
-        localIdentifier: "m1",
-        alias: "Measure M1",
-        definition: {
-            measureDefinition: {
-                item: {
-                    uri: "/gdc/md/project/obj/metric.id",
-                },
-                filters: [
-                    {
-                        relativeDateFilter: {
-                            dataSet: {
-                                uri: "/gdc/md/project/333",
-                            },
-                            granularity: "GDC.time.date",
-                            from: -89,
-                            to: 0,
-                        },
-                    },
-                    {
-                        positiveAttributeFilter: {
-                            displayForm: {
-                                uri: "/gdc/md/project/obj/1",
-                            },
-                            in: [`${"/gdc/md/project/obj/11"}?id=1`, `${"/gdc/md/project/obj/11"}?id=2`],
-                        },
-                    },
-                ],
-            },
-        },
-    },
-};
-
-export const measureWithAbsoluteDate: IMeasure = {
+export const measureWithFilters: IMeasure = {
     measure: {
         localIdentifier: "m1",
         alias: "Measure M1",
@@ -156,6 +61,16 @@ export const measureWithAbsoluteDate: IMeasure = {
                             },
                             from: "2016-01-01",
                             to: "2017-01-01",
+                        },
+                    },
+                    {
+                        relativeDateFilter: {
+                            dataSet: {
+                                uri: "/gdc/md/project/333",
+                            },
+                            granularity: "GDC.time.date",
+                            from: -89,
+                            to: 0,
                         },
                     },
                     {
@@ -186,25 +101,9 @@ export const factBasedMeasure: IMeasure = {
     },
 };
 
-export const factBasedRenamedMeasure: IMeasure = {
-    measure: {
-        localIdentifier: "m1",
-        alias: "Summary",
-        definition: {
-            measureDefinition: {
-                item: {
-                    uri: "/gdc/md/project/obj/fact.id",
-                },
-                aggregation: "sum",
-            },
-        },
-    },
-};
-
 export const attributeBasedMeasure: IMeasure = {
     measure: {
         localIdentifier: "m1",
-        format: "$#,##0.00",
         definition: {
             measureDefinition: {
                 item: {
@@ -216,53 +115,7 @@ export const attributeBasedMeasure: IMeasure = {
     },
 };
 
-export const attributeBasedMeasureWithoutFormat: IMeasure = {
-    measure: {
-        localIdentifier: "m1",
-        definition: {
-            measureDefinition: {
-                item: {
-                    uri: "/gdc/md/project/obj/1",
-                },
-                aggregation: "count",
-            },
-        },
-    },
-};
-
-export const attributeBasedRenamedMeasure: IMeasure = {
-    measure: {
-        localIdentifier: "m1",
-        alias: "Count",
-        format: "$#,##0.00",
-        definition: {
-            measureDefinition: {
-                item: {
-                    uri: "/gdc/md/project/obj/1",
-                },
-                aggregation: "count",
-            },
-        },
-    },
-};
-
-export const showInPercent: IMeasure = {
-    measure: {
-        localIdentifier: "m1",
-        alias: "Measure M1",
-        format: "$#,##0.00",
-        definition: {
-            measureDefinition: {
-                item: {
-                    uri: "/gdc/md/project/obj/metric.id",
-                },
-                computeRatio: true,
-            },
-        },
-    },
-};
-
-export const showInPercentWithoutFormat: IMeasure = {
+export const showInPercentMeasure: IMeasure = {
     measure: {
         localIdentifier: "m1",
         alias: "Measure M1",
@@ -318,24 +171,28 @@ export const previousPeriodMeasure: IMeasure = {
     },
 };
 
-export function buildArithmeticMeasure(
-    localIdentifier: string = "arithmetic_measure_1",
-    customDefinition?: Partial<VisualizationObject.IArithmeticMeasureDefinition["arithmeticMeasure"]>,
-    alias?: string,
-): IMeasure {
-    const arithmeticMeasure: VisualizationObject.IArithmeticMeasureDefinition["arithmeticMeasure"] = {
-        measureIdentifiers: ["m1", "m2"],
-        operator: "sum",
-        ...customDefinition,
-    };
-
-    return {
-        measure: {
-            localIdentifier,
-            ...(alias && { alias }),
-            definition: {
-                arithmeticMeasure,
+export const arithmeticMeasure: IMeasure = {
+    measure: {
+        localIdentifier: "arithmetic_measure_1",
+        alias: "Sum of m1 and m2",
+        definition: {
+            arithmeticMeasure: {
+                measureIdentifiers: ["m1", "m2"],
+                operator: "sum",
             },
         },
-    };
-}
+    },
+};
+
+export const arithmeticMeasureChange: IMeasure = {
+    measure: {
+        localIdentifier: "arithmetic_measure_1",
+        alias: "Sum of m1 and m2",
+        definition: {
+            arithmeticMeasure: {
+                measureIdentifiers: ["m1", "m2"],
+                operator: "change",
+            },
+        },
+    },
+};


### PR DESCRIPTION
toAfmResultSpec is adding default formats to attribute-based measures(whole number), show in % measures(percentage) and arithmetic measures with operator change(percentage) It was preferring these default formats over formats from the provided visualization object which is fixed by this PR. 

Note that for fact-based measures the default format is not generated which is strange but not fixed by this PR

---

<!--
 Choose one of the three release types this change will be released as.
 When a change MUST be major:
 * backwards incompatible change in functionality - this includes:
   * removing/changing the order of parameters in a public function
   * removing/renaming a public module
 * backwards incompatible change in TypeScript types - this includes:
   * changing a type of a function parameters/return type to an incompatible type (e.g. number to string; number to number | string is fine)
 * major upgrade of ANY dependency
 * minor upgrade of typescript
 * changes in build logic that could make the output incompatible
 -->

**Proposed release type:** major|minor|patch (see points 6. - 8. of the [semver spec](https://semver.org/#semantic-versioning-specification-semver))

# PR checklist

- [ ] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [ ] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] The proposed release type is appropriate (see the comment in [PR template](../blob/master/.github/pull_request_template.md))
