### PR TITLE
BUGFIX: BB-2286 Override default format of ad-hoc % measures

### DIFF
--- a/src/DataLayer/constants/formats.ts
+++ b/src/DataLayer/constants/formats.ts
@@ -1,3 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
-export const SHOW_IN_PERCENT_MEASURE_FORMAT = "#,##0.00%";
-export const DEFAULT_METRIC_FORMAT = "#,##0.00";
+// (C) 2007-2020 GoodData Corporation
+export const DEFAULT_DECIMAL_FORMAT = "#,##0.00";
+export const DEFAULT_PERCENTAGE_FORMAT = "#,##0.00%";
+export const DEFAULT_INTEGER_FORMAT = "#,##0";

--- a/src/DataLayer/converters/tests/MeasureConverter.spec.ts
+++ b/src/DataLayer/converters/tests/MeasureConverter.spec.ts
@@ -4,37 +4,47 @@ import * as afm from "./fixtures/MeasureConverter.afm.fixtures";
 import MeasureConverter from "../MeasureConverter";
 import { VisualizationObject } from "@gooddata/typings";
 import IMeasure = VisualizationObject.IMeasure;
+import { DEFAULT_DECIMAL_FORMAT, DEFAULT_INTEGER_FORMAT } from "../../constants/formats";
 
-function addFormat(measure: IMeasure) {
+function addFormat(measure: IMeasure, format: string = "$#,##0 custom") {
     return {
         measure: {
             ...measure.measure,
-            format: "$#,##0 custom",
+            format,
         },
     };
 }
 
+const addDecFormat = (measure: IMeasure) => addFormat(measure, DEFAULT_DECIMAL_FORMAT);
+const addIntFormat = (measure: IMeasure) => addFormat(measure, DEFAULT_INTEGER_FORMAT);
+
 describe("convertMeasure", () => {
     it.each`
-        testCase                                                 | inputVizObjMeasure                             | outputAfmMeasure
-        ${"simple measures defined by URI"}                      | ${measures.simpleMeasureWithUri}               | ${afm.simpleMeasureWithUri}
-        ${"simple measure defined by identifier"}                | ${measures.simpleMeasureWithIdentifiers}       | ${afm.simpleMeasureWithIdentifiers}
-        ${"simple measure, keeping custom format"}               | ${addFormat(measures.simpleMeasureWithUri)}    | ${afm.simpleMeasureWithFormat}
-        ${"measure with filters"}                                | ${measures.measureWithFilters}                 | ${afm.measureWithFilters}
-        ${"renamed measure"}                                     | ${measures.renamedMeasure}                     | ${afm.renamedMeasure}
-        ${"fact-based measure, not adding default format"}       | ${measures.factBasedMeasure}                   | ${afm.factBasedMeasure}
-        ${"fact-based measure, keeping custom format"}           | ${addFormat(measures.factBasedMeasure)}        | ${afm.factBasedMeasureWithCustomFormat}
-        ${"attribute-based measure, adding default format"}      | ${measures.attributeBasedMeasure}              | ${afm.attributeBasedMeasure}
-        ${"attribute-based measure, keeping custom format"}      | ${addFormat(measures.attributeBasedMeasure)}   | ${afm.attributeBasedMeasureWithCustomFormat}
-        ${"POP measure, not adding default format"}              | ${measures.popMeasure}                         | ${afm.popMeasure}
-        ${"POP measure, keeping default format"}                 | ${addFormat(measures.popMeasure)}              | ${afm.popMeasureWithCustomFormat}
-        ${"previous period measure, not adding default format"}  | ${measures.previousPeriodMeasure}              | ${afm.previousPeriodMeasure}
-        ${"measure with show in percent, adding default format"} | ${measures.showInPercentMeasure}               | ${afm.showInPercentMeasure}
-        ${"measure with show in percent, keeping custom format"} | ${addFormat(measures.showInPercentMeasure)}    | ${afm.showInPercentWithCustomFormat}
-        ${"arithmetic measure, not adding default format"}       | ${measures.arithmeticMeasure}                  | ${afm.arithmeticMeasure}
-        ${"arithmetic measure, keeping custom format"}           | ${addFormat(measures.arithmeticMeasure)}       | ${afm.arithmeticMeasureWithCustomFormat}
-        ${"arithmetic measure-change, adding default format"}    | ${measures.arithmeticMeasureChange}            | ${afm.arithmeticMeasureChange}
-        ${"arithmetic measure-change, keeping custom format"}    | ${addFormat(measures.arithmeticMeasureChange)} | ${afm.arithmeticMeasureWithChangeOperatorAndCustomFormat}
+        testCase                                                  | inputVizObjMeasure                                       | outputAfmMeasure
+        ${"simple measures defined by URI"}                       | ${measures.simpleMeasureWithUri}                         | ${afm.simpleMeasureWithUri}
+        ${"simple measure defined by identifier"}                 | ${measures.simpleMeasureWithIdentifiers}                 | ${afm.simpleMeasureWithIdentifiers}
+        ${"simple measure, keeping custom format"}                | ${addFormat(measures.simpleMeasureWithUri)}              | ${afm.simpleMeasureWithFormat}
+        ${"measure with filters"}                                 | ${measures.measureWithFilters}                           | ${afm.measureWithFilters}
+        ${"renamed measure"}                                      | ${measures.renamedMeasure}                               | ${afm.renamedMeasure}
+        ${"fact-based measure, not adding default format"}        | ${measures.factBasedMeasure}                             | ${afm.factBasedMeasure}
+        ${"fact-based measure, keeping custom format"}            | ${addFormat(measures.factBasedMeasure)}                  | ${afm.factBasedMeasureWithCustomFormat}
+        ${"fact-based measure in %, adding default format"}       | ${measures.factBasedMeasureInPercent}                    | ${afm.factBasedMeasureInPercent}
+        ${"fact-based measure in %, keeping custom format"}       | ${addFormat(measures.factBasedMeasureInPercent)}         | ${afm.factBasedMeasureInPercentWithCustomFormat}
+        ${"fact-based measure in %, overriding incorrect format"} | ${addDecFormat(measures.factBasedMeasureInPercent)}      | ${afm.factBasedMeasureInPercent}
+        ${"attribute-based measure, adding default format"}       | ${measures.attributeBasedMeasure}                        | ${afm.attributeBasedMeasure}
+        ${"attribute-based measure, keeping custom format"}       | ${addFormat(measures.attributeBasedMeasure)}             | ${afm.attributeBasedMeasureWithCustomFormat}
+        ${"attribute-based measure in %, adding default format"}  | ${measures.attributeBasedMeasureInPercent}               | ${afm.attributeBasedMeasureInPercent}
+        ${"attribute-based measure in %, keeping custom format"}  | ${addFormat(measures.attributeBasedMeasureInPercent)}    | ${afm.attributeBasedMeasureInPercentWithCustomFormat}
+        ${"attribute-based m. in %, overriding default format"}   | ${addIntFormat(measures.attributeBasedMeasureInPercent)} | ${afm.attributeBasedMeasureInPercent}
+        ${"POP measure, not adding default format"}               | ${measures.popMeasure}                                   | ${afm.popMeasure}
+        ${"POP measure, keeping default format"}                  | ${addFormat(measures.popMeasure)}                        | ${afm.popMeasureWithCustomFormat}
+        ${"previous period measure, not adding default format"}   | ${measures.previousPeriodMeasure}                        | ${afm.previousPeriodMeasure}
+        ${"measure with show in percent, adding default format"}  | ${measures.showInPercentMeasure}                         | ${afm.showInPercentMeasure}
+        ${"measure with show in percent, keeping custom format"}  | ${addFormat(measures.showInPercentMeasure)}              | ${afm.showInPercentWithCustomFormat}
+        ${"arithmetic measure, not adding default format"}        | ${measures.arithmeticMeasure}                            | ${afm.arithmeticMeasure}
+        ${"arithmetic measure, keeping custom format"}            | ${addFormat(measures.arithmeticMeasure)}                 | ${afm.arithmeticMeasureWithCustomFormat}
+        ${"arithmetic measure-change, adding default format"}     | ${measures.arithmeticMeasureChange}                      | ${afm.arithmeticMeasureChange}
+        ${"arithmetic measure-change, keeping custom format"}     | ${addFormat(measures.arithmeticMeasureChange)}           | ${afm.arithmeticMeasureWithChangeOperatorAndCustomFormat}
     `(`should convert $testCase`, ({ inputVizObjMeasure, outputAfmMeasure }) => {
         expect(MeasureConverter.convertMeasure(inputVizObjMeasure)).toEqual(outputAfmMeasure);
     });

--- a/src/DataLayer/converters/tests/fixtures/MeasureConverter.afm.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/MeasureConverter.afm.fixtures.ts
@@ -132,6 +132,34 @@ export const factBasedMeasure: IMeasure = {
     },
 };
 
+export const factBasedMeasureInPercent: IMeasure = {
+    localIdentifier: "m1",
+    definition: {
+        measure: {
+            item: {
+                uri: "/gdc/md/project/obj/fact.id",
+            },
+            aggregation: "sum",
+            computeRatio: true,
+        },
+    },
+    format: "#,##0.00%",
+};
+
+export const factBasedMeasureInPercentWithCustomFormat: IMeasure = {
+    localIdentifier: "m1",
+    definition: {
+        measure: {
+            item: {
+                uri: "/gdc/md/project/obj/fact.id",
+            },
+            aggregation: "sum",
+            computeRatio: true,
+        },
+    },
+    format: "$#,##0 custom",
+};
+
 export const factBasedMeasureWithCustomFormat: IMeasure = {
     localIdentifier: "m1",
     definition: {
@@ -158,6 +186,20 @@ export const attributeBasedMeasure: IMeasure = {
     format: "#,##0",
 };
 
+export const attributeBasedMeasureInPercent: IMeasure = {
+    localIdentifier: "m1",
+    definition: {
+        measure: {
+            item: {
+                uri: "/gdc/md/project/obj/1",
+            },
+            aggregation: "count",
+            computeRatio: true,
+        },
+    },
+    format: "#,##0.00%",
+};
+
 export const attributeBasedMeasureWithCustomFormat: IMeasure = {
     localIdentifier: "m1",
     definition: {
@@ -166,6 +208,20 @@ export const attributeBasedMeasureWithCustomFormat: IMeasure = {
                 uri: "/gdc/md/project/obj/1",
             },
             aggregation: "count",
+        },
+    },
+    format: "$#,##0 custom",
+};
+
+export const attributeBasedMeasureInPercentWithCustomFormat: IMeasure = {
+    localIdentifier: "m1",
+    definition: {
+        measure: {
+            item: {
+                uri: "/gdc/md/project/obj/1",
+            },
+            aggregation: "count",
+            computeRatio: true,
         },
     },
     format: "$#,##0 custom",

--- a/src/DataLayer/converters/tests/fixtures/MeasureConverter.visObj.fixtures.ts
+++ b/src/DataLayer/converters/tests/fixtures/MeasureConverter.visObj.fixtures.ts
@@ -101,6 +101,21 @@ export const factBasedMeasure: IMeasure = {
     },
 };
 
+export const factBasedMeasureInPercent: IMeasure = {
+    measure: {
+        localIdentifier: "m1",
+        definition: {
+            measureDefinition: {
+                item: {
+                    uri: "/gdc/md/project/obj/fact.id",
+                },
+                aggregation: "sum",
+                computeRatio: true,
+            },
+        },
+    },
+};
+
 export const attributeBasedMeasure: IMeasure = {
     measure: {
         localIdentifier: "m1",
@@ -110,6 +125,21 @@ export const attributeBasedMeasure: IMeasure = {
                     uri: "/gdc/md/project/obj/1",
                 },
                 aggregation: "count",
+            },
+        },
+    },
+};
+
+export const attributeBasedMeasureInPercent: IMeasure = {
+    measure: {
+        localIdentifier: "m1",
+        definition: {
+            measureDefinition: {
+                item: {
+                    uri: "/gdc/md/project/obj/1",
+                },
+                aggregation: "count",
+                computeRatio: true,
             },
         },
     },


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

<!--
 Choose one of the three release types this change will be released as.
 When a change MUST be major:
 * backwards incompatible change in functionality - this includes:
   * removing/changing the order of parameters in a public function
   * removing/renaming a public module
 * backwards incompatible change in TypeScript types - this includes:
   * changing a type of a function parameters/return type to an incompatible type (e.g. number to string; number to number | string is fine)
 * major upgrade of ANY dependency
 * minor upgrade of typescript
 * changes in build logic that could make the output incompatible
 -->

**Proposed release type:** major|minor|patch (see points 6. - 8. of the [semver spec](https://semver.org/#semantic-versioning-specification-semver))

# PR checklist

- [ ] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [ ] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] The proposed release type is appropriate (see the comment in [PR template](../blob/master/.github/pull_request_template.md))
