### PR TITLE
RELATED: ONE-4414 Support for properties in Widget MD object

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "webpack-dev-server": "^1.16.5"
   },
   "dependencies": {
-    "@gooddata/typings": "^2.25.0",
+    "@gooddata/typings": "^2.26.0",
     "es6-promise": "^3.0.2",
     "fetch-cookie": "^0.7.0",
     "invariant": "^2.2.2",

--- a/src/gooddata.ts
+++ b/src/gooddata.ts
@@ -13,7 +13,7 @@ import { AdminModule } from "./admin";
 
 import { AttributesMapLoaderModule } from "./utils/attributesMapLoader";
 import { getAttributesDisplayForms } from "./utils/visualizationObjectHelper";
-import { convertReferencesToUris, ReferenceConverter } from "./referenceHandling";
+import { convertReferencesToUris, convertUrisToReferences, ReferenceConverter } from "./referenceHandling";
 import { MetadataModuleExt } from "./metadataExt";
 import { BootstrapModule } from "./bootstrap";
 
@@ -52,6 +52,7 @@ export class SDK {
         loadAttributesMap: any;
         getAttributesDisplayForms: any;
         convertReferencesToUris: ReferenceConverter;
+        convertUrisToReferences: ReferenceConverter;
     };
 
     constructor(private fetchMethod: typeof fetch, config = {}) {
@@ -75,6 +76,7 @@ export class SDK {
             loadAttributesMap: attributesMapLoaderModule.loadAttributesMap.bind(attributesMapLoaderModule),
             getAttributesDisplayForms,
             convertReferencesToUris,
+            convertUrisToReferences,
         };
     }
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -72,6 +72,11 @@ export class MetadataModule {
                                 visualizationObject: convertReferencesToUris(item.visualizationObject),
                             };
                         }
+                        if (item.visualizationWidget) {
+                            return {
+                                visualizationWidget: convertReferencesToUris(item.visualizationWidget),
+                            };
+                        }
                         return item;
                     }),
                 );
@@ -734,7 +739,9 @@ export class MetadataModule {
             (visualizationObject: VisualizationObject.IVisualizationObjectResponse) => {
                 const mdObject = visualizationObject.visualizationObject;
                 return {
-                    visualizationObject: convertReferencesToUris(mdObject),
+                    visualizationObject: convertReferencesToUris(
+                        mdObject,
+                    ) as VisualizationObject.IVisualizationObject,
                 };
             },
         );

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -846,7 +846,7 @@ describe("metadata", () => {
                     });
             });
 
-            it("should translate properties using references", () => {
+            it("should translate visualizationObject properties using references", () => {
                 const uris = ["/gdc/md/123/obj/456"];
                 const serverResponses = [
                     {
@@ -861,6 +861,49 @@ describe("metadata", () => {
                 const expectedResponses = [
                     {
                         visualizationObject: {
+                            content: {
+                                properties: '{"foo":"/gdc/md/123/obj/45678"}',
+                                references: { id_0: "/gdc/md/123/obj/45678" },
+                            },
+                        },
+                    },
+                ];
+
+                fetchMock.mock(getUri, {
+                    status: 200,
+                    body: JSON.stringify({ objects: { items: serverResponses } }),
+                });
+
+                return createMd()
+                    .getObjects(projectId, uris)
+                    .then((result: any) => {
+                        const request = fetchMock.lastOptions(getUri) as RequestInit;
+
+                        expect(JSON.parse(request.body!.toString())).toEqual({
+                            get: {
+                                items: uris,
+                            },
+                        });
+
+                        expect(result).toEqual(expectedResponses);
+                    });
+            });
+
+            it("should translate visualizationWidget properties using references", () => {
+                const uris = ["/gdc/md/123/obj/456"];
+                const serverResponses = [
+                    {
+                        visualizationWidget: {
+                            content: {
+                                properties: '{"foo":"id_0"}',
+                                references: { id_0: "/gdc/md/123/obj/45678" },
+                            },
+                        },
+                    },
+                ];
+                const expectedResponses = [
+                    {
+                        visualizationWidget: {
                             content: {
                                 properties: '{"foo":"/gdc/md/123/obj/45678"}',
                                 references: { id_0: "/gdc/md/123/obj/45678" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,10 +283,10 @@
     tslint-microsoft-contrib "6.1.0"
     tslint-react "3.6.0"
 
-"@gooddata/typings@^2.25.0":
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.25.0.tgz#85fc630ae971770ade197a52ea96a0ef967ce7a1"
-  integrity sha512-EyNTaoyiPSqa+hFrvbTLwwDo857CaOw+2/FUPAgqvljWNejfMV/+rfdFsDidOoNgYlgcVb7sXZuSEjj0aMue8w==
+"@gooddata/typings@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.26.0.tgz#660ef7ccf96bbcb0e6ed1e1b8df85528fbe42f6c"
+  integrity sha512-le1CeojbDRDHxZBCvIyd4mMy7ZeTLbcbV8hh9iHEFfKCU8eXQx9Oe5+mMa6OqPOmRwVvrSGL90TGaI/eoVRg6A==
   dependencies:
     lodash "^4.17.11"
 


### PR DESCRIPTION
Extend handling of properties+references to the VisualizationWidget

---

<!--
 Choose one of the three release types this change will be released as.
 When a change MUST be major:
 * backwards incompatible change in functionality - this includes:
   * removing/changing the order of parameters in a public function
   * removing/renaming a public module
 * backwards incompatible change in TypeScript types - this includes:
   * changing a type of a function parameters/return type to an incompatible type (e.g. number to string; number to number | string is fine)
 * major upgrade of ANY dependency
 * minor upgrade of typescript
 * changes in build logic that could make the output incompatible
 -->

**Proposed release type:** major|minor|patch (see points 6. - 8. of the [semver spec](https://semver.org/#semantic-versioning-specification-semver))

# PR checklist

- [ ] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [ ] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] The proposed release type is appropriate (see the comment in [PR template](../blob/master/.github/pull_request_template.md))
