### PR TITLE
Add summary to save dashboard as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The REST API versions in the table are just for your information as the values a
 |\>= 10.0.0|3
 |<= 9.0.1|2
 
+<a name="13.1.3"></a>
+## 2020-08-04 Version [13.1.3](https://github.com/gooddata/gooddata-js/compare/v13.1.1...v13.1.3)
+
+- add optional summary attribute to saveDashboardAs options parameter
+
 <a name="13.1.1"></a>
 ## 2020-08-04 Version [13.1.0](https://github.com/gooddata/gooddata-js/compare/v13.1.0...v13.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The REST API versions in the table are just for your information as the values a
 |\>= 10.0.0|3
 |<= 9.0.1|2
 
-<a name="13.1.3"></a>
-## 2020-08-04 Version [13.1.3](https://github.com/gooddata/gooddata-js/compare/v13.1.1...v13.1.3)
+<a name="13.2.0"></a>
+## 2020-08-04 Version [13.1.3](https://github.com/gooddata/gooddata-js/compare/v13.1.1...v13.2.0)
 
 - add optional summary attribute to saveDashboardAs options parameter
 

--- a/src/metadataExt.ts
+++ b/src/metadataExt.ts
@@ -24,6 +24,8 @@ export interface ICopyDashboardOptions {
     copyVisObj?: boolean;
     /** optional, default value of name is "Copy of (current dashboard title)" */
     name?: string;
+    /** optional, default value of summary is (current dashboard summary) */
+    summary?: string;
 }
 
 type UriTranslator = (oldUri: string) => string;
@@ -125,6 +127,10 @@ export class MetadataModuleExt {
             const translator = createTranslator(kpiMap, visWidgetMap);
             const updatedContent = updateContent(analyticalDashboard, translator, filterContext);
             const dashboardTitle = this.getDashboardName(analyticalDashboard.meta.title, options.name);
+            const dashboardSummary = this.getDashboardSummary(
+                analyticalDashboard.meta.summary,
+                options.summary,
+            );
             const duplicateDashboard = {
                 ...dashboardDetails,
                 analyticalDashboard: {
@@ -140,6 +146,7 @@ export class MetadataModuleExt {
                             "contributor",
                         ]),
                         title: dashboardTitle,
+                        summary: dashboardSummary,
                     },
                 },
             };
@@ -208,6 +215,15 @@ export class MetadataModuleExt {
             return newName;
         }
         return `Copy of ${originalName}`;
+    }
+
+    private getDashboardSummary(originalSummary?: string, newSummary?: string): string {
+        if (newSummary !== undefined) {
+            return newSummary;
+        } else if (originalSummary !== undefined) {
+            return originalSummary;
+        }
+        return "";
     }
 
     private async duplicateOrKeepKpis(


### PR DESCRIPTION
Add new optional attribute, `summary`,  to metadataExt.saveDashboard `options` param

---

<!--
 Choose one of the three release types this change will be released as.
 When a change MUST be major:
 * backwards incompatible change in functionality - this includes:
   * removing/changing the order of parameters in a public function
   * removing/renaming a public module
 * backwards incompatible change in TypeScript types - this includes:
   * changing a type of a function parameters/return type to an incompatible type (e.g. number to string; number to number | string is fine)
 * major upgrade of ANY dependency
 * minor upgrade of typescript
 * changes in build logic that could make the output incompatible
 -->

**Proposed release type:** minor
(see points 6. - 8. of the [semver spec](https://semver.org/#semantic-versioning-specification-semver))

# PR checklist

- [ ] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [x] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] The proposed release type is appropriate (see the comment in [PR template](../blob/master/.github/pull_request_template.md))
