### PR TITLE
BUGFIX: BB-2305 Remove temporary measure format override

### DIFF
--- a/src/DataLayer/converters/MeasureConverter.ts
+++ b/src/DataLayer/converters/MeasureConverter.ts
@@ -10,11 +10,7 @@ import IPoPMeasureDefinition = VisualizationObject.IPoPMeasureDefinition;
 import IPreviousPeriodMeasureDefinition = VisualizationObject.IPreviousPeriodMeasureDefinition;
 
 import { convertVisualizationObjectFilter } from "./FilterConverter";
-import {
-    DEFAULT_DECIMAL_FORMAT,
-    DEFAULT_INTEGER_FORMAT,
-    DEFAULT_PERCENTAGE_FORMAT,
-} from "../constants/formats";
+import { DEFAULT_INTEGER_FORMAT, DEFAULT_PERCENTAGE_FORMAT } from "../constants/formats";
 
 const MeasureConverter = {
     convertMeasure,
@@ -122,24 +118,6 @@ function getFormat(measure: IMeasure): string | undefined {
     const {
         measure: { definition, format },
     } = measure;
-
-    // Override incorrect formats of ad-hoc measures with computeRatio
-    // and use decimal percentage  instead.
-    // This code will be removed once saved viz. objects are fixed in BB-2287
-    if (VisualizationObject.isMeasureDefinition(definition)) {
-        const { measureDefinition } = definition;
-        if (measureDefinition.computeRatio && measureDefinition.aggregation) {
-            if (measureDefinition.aggregation === "count") {
-                if (format === DEFAULT_INTEGER_FORMAT) {
-                    return DEFAULT_PERCENTAGE_FORMAT;
-                }
-            } else {
-                if (format === DEFAULT_DECIMAL_FORMAT) {
-                    return DEFAULT_PERCENTAGE_FORMAT;
-                }
-            }
-        }
-    }
 
     if (format) {
         return format;

--- a/src/DataLayer/converters/tests/MeasureConverter.spec.ts
+++ b/src/DataLayer/converters/tests/MeasureConverter.spec.ts
@@ -4,7 +4,6 @@ import * as afm from "./fixtures/MeasureConverter.afm.fixtures";
 import MeasureConverter from "../MeasureConverter";
 import { VisualizationObject } from "@gooddata/typings";
 import IMeasure = VisualizationObject.IMeasure;
-import { DEFAULT_DECIMAL_FORMAT, DEFAULT_INTEGER_FORMAT } from "../../constants/formats";
 
 function addFormat(measure: IMeasure, format: string = "$#,##0 custom") {
     return {
@@ -15,36 +14,31 @@ function addFormat(measure: IMeasure, format: string = "$#,##0 custom") {
     };
 }
 
-const addDecFormat = (measure: IMeasure) => addFormat(measure, DEFAULT_DECIMAL_FORMAT);
-const addIntFormat = (measure: IMeasure) => addFormat(measure, DEFAULT_INTEGER_FORMAT);
-
 describe("convertMeasure", () => {
     it.each`
-        testCase                                                  | inputVizObjMeasure                                       | outputAfmMeasure
-        ${"simple measures defined by URI"}                       | ${measures.simpleMeasureWithUri}                         | ${afm.simpleMeasureWithUri}
-        ${"simple measure defined by identifier"}                 | ${measures.simpleMeasureWithIdentifiers}                 | ${afm.simpleMeasureWithIdentifiers}
-        ${"simple measure, keeping custom format"}                | ${addFormat(measures.simpleMeasureWithUri)}              | ${afm.simpleMeasureWithFormat}
-        ${"measure with filters"}                                 | ${measures.measureWithFilters}                           | ${afm.measureWithFilters}
-        ${"renamed measure"}                                      | ${measures.renamedMeasure}                               | ${afm.renamedMeasure}
-        ${"fact-based measure, not adding default format"}        | ${measures.factBasedMeasure}                             | ${afm.factBasedMeasure}
-        ${"fact-based measure, keeping custom format"}            | ${addFormat(measures.factBasedMeasure)}                  | ${afm.factBasedMeasureWithCustomFormat}
-        ${"fact-based measure in %, adding default format"}       | ${measures.factBasedMeasureInPercent}                    | ${afm.factBasedMeasureInPercent}
-        ${"fact-based measure in %, keeping custom format"}       | ${addFormat(measures.factBasedMeasureInPercent)}         | ${afm.factBasedMeasureInPercentWithCustomFormat}
-        ${"fact-based measure in %, overriding incorrect format"} | ${addDecFormat(measures.factBasedMeasureInPercent)}      | ${afm.factBasedMeasureInPercent}
-        ${"attribute-based measure, adding default format"}       | ${measures.attributeBasedMeasure}                        | ${afm.attributeBasedMeasure}
-        ${"attribute-based measure, keeping custom format"}       | ${addFormat(measures.attributeBasedMeasure)}             | ${afm.attributeBasedMeasureWithCustomFormat}
-        ${"attribute-based measure in %, adding default format"}  | ${measures.attributeBasedMeasureInPercent}               | ${afm.attributeBasedMeasureInPercent}
-        ${"attribute-based measure in %, keeping custom format"}  | ${addFormat(measures.attributeBasedMeasureInPercent)}    | ${afm.attributeBasedMeasureInPercentWithCustomFormat}
-        ${"attribute-based m. in %, overriding default format"}   | ${addIntFormat(measures.attributeBasedMeasureInPercent)} | ${afm.attributeBasedMeasureInPercent}
-        ${"POP measure, not adding default format"}               | ${measures.popMeasure}                                   | ${afm.popMeasure}
-        ${"POP measure, keeping default format"}                  | ${addFormat(measures.popMeasure)}                        | ${afm.popMeasureWithCustomFormat}
-        ${"previous period measure, not adding default format"}   | ${measures.previousPeriodMeasure}                        | ${afm.previousPeriodMeasure}
-        ${"measure with show in percent, adding default format"}  | ${measures.showInPercentMeasure}                         | ${afm.showInPercentMeasure}
-        ${"measure with show in percent, keeping custom format"}  | ${addFormat(measures.showInPercentMeasure)}              | ${afm.showInPercentWithCustomFormat}
-        ${"arithmetic measure, not adding default format"}        | ${measures.arithmeticMeasure}                            | ${afm.arithmeticMeasure}
-        ${"arithmetic measure, keeping custom format"}            | ${addFormat(measures.arithmeticMeasure)}                 | ${afm.arithmeticMeasureWithCustomFormat}
-        ${"arithmetic measure-change, adding default format"}     | ${measures.arithmeticMeasureChange}                      | ${afm.arithmeticMeasureChange}
-        ${"arithmetic measure-change, keeping custom format"}     | ${addFormat(measures.arithmeticMeasureChange)}           | ${afm.arithmeticMeasureWithChangeOperatorAndCustomFormat}
+        testCase                                                 | inputVizObjMeasure                                    | outputAfmMeasure
+        ${"simple measures defined by URI"}                      | ${measures.simpleMeasureWithUri}                      | ${afm.simpleMeasureWithUri}
+        ${"simple measure defined by identifier"}                | ${measures.simpleMeasureWithIdentifiers}              | ${afm.simpleMeasureWithIdentifiers}
+        ${"simple measure, keeping custom format"}               | ${addFormat(measures.simpleMeasureWithUri)}           | ${afm.simpleMeasureWithFormat}
+        ${"measure with filters"}                                | ${measures.measureWithFilters}                        | ${afm.measureWithFilters}
+        ${"renamed measure"}                                     | ${measures.renamedMeasure}                            | ${afm.renamedMeasure}
+        ${"fact-based measure, not adding default format"}       | ${measures.factBasedMeasure}                          | ${afm.factBasedMeasure}
+        ${"fact-based measure, keeping custom format"}           | ${addFormat(measures.factBasedMeasure)}               | ${afm.factBasedMeasureWithCustomFormat}
+        ${"fact-based measure in %, adding default format"}      | ${measures.factBasedMeasureInPercent}                 | ${afm.factBasedMeasureInPercent}
+        ${"fact-based measure in %, keeping custom format"}      | ${addFormat(measures.factBasedMeasureInPercent)}      | ${afm.factBasedMeasureInPercentWithCustomFormat}
+        ${"attribute-based measure, adding default format"}      | ${measures.attributeBasedMeasure}                     | ${afm.attributeBasedMeasure}
+        ${"attribute-based measure, keeping custom format"}      | ${addFormat(measures.attributeBasedMeasure)}          | ${afm.attributeBasedMeasureWithCustomFormat}
+        ${"attribute-based measure in %, adding default format"} | ${measures.attributeBasedMeasureInPercent}            | ${afm.attributeBasedMeasureInPercent}
+        ${"attribute-based measure in %, keeping custom format"} | ${addFormat(measures.attributeBasedMeasureInPercent)} | ${afm.attributeBasedMeasureInPercentWithCustomFormat}
+        ${"POP measure, not adding default format"}              | ${measures.popMeasure}                                | ${afm.popMeasure}
+        ${"POP measure, keeping default format"}                 | ${addFormat(measures.popMeasure)}                     | ${afm.popMeasureWithCustomFormat}
+        ${"previous period measure, not adding default format"}  | ${measures.previousPeriodMeasure}                     | ${afm.previousPeriodMeasure}
+        ${"measure with show in percent, adding default format"} | ${measures.showInPercentMeasure}                      | ${afm.showInPercentMeasure}
+        ${"measure with show in percent, keeping custom format"} | ${addFormat(measures.showInPercentMeasure)}           | ${afm.showInPercentWithCustomFormat}
+        ${"arithmetic measure, not adding default format"}       | ${measures.arithmeticMeasure}                         | ${afm.arithmeticMeasure}
+        ${"arithmetic measure, keeping custom format"}           | ${addFormat(measures.arithmeticMeasure)}              | ${afm.arithmeticMeasureWithCustomFormat}
+        ${"arithmetic measure-change, adding default format"}    | ${measures.arithmeticMeasureChange}                   | ${afm.arithmeticMeasureChange}
+        ${"arithmetic measure-change, keeping custom format"}    | ${addFormat(measures.arithmeticMeasureChange)}        | ${afm.arithmeticMeasureWithChangeOperatorAndCustomFormat}
     `(`should convert $testCase`, ({ inputVizObjMeasure, outputAfmMeasure }) => {
         expect(MeasureConverter.convertMeasure(inputVizObjMeasure)).toEqual(outputAfmMeasure);
     });


### PR DESCRIPTION
When implementing custom measure format we found out that some measures have incorrect format saved in metadata object. As we started to respect the format saved in viz. object the measures would be formatted wrongly so we introduced this fix for them. In https://jira.intgdc.com/browse/MDC-217 these measures have been fixed so that the override is not needed any more 

---

<!--
 Choose one of the three release types this change will be released as.
 When a change MUST be major:
 * backwards incompatible change in functionality - this includes:
   * removing/changing the order of parameters in a public function
   * removing/renaming a public module
 * backwards incompatible change in TypeScript types - this includes:
   * changing a type of a function parameters/return type to an incompatible type (e.g. number to string; number to number | string is fine)
 * major upgrade of ANY dependency
 * minor upgrade of typescript
 * changes in build logic that could make the output incompatible
 -->

**Proposed release type:** major|minor|patch (see points 6. - 8. of the [semver spec](https://semver.org/#semantic-versioning-specification-semver))

# PR checklist

- [ ] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable).
- [ ] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] The proposed release type is appropriate (see the comment in [PR template](../blob/master/.github/pull_request_template.md))
