### PR TITLE
RELATED: RAIL-2860 Add clearLockedFlag option to saveDashboardAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The REST API versions in the table are just for your information as the values a
 |\>= 10.0.0|3
 |<= 9.0.1|2
 
+<a name="13.3.0"></a>
+## 2020-12-18 Version [13.3.0](https://github.com/gooddata/gooddata-js/compare/v13.2.0...v13.3.0)
+
+- Add the clearLockedFlag option to saveDashboardAs function
+
 <a name="13.2.0"></a>
 ## 2020-11-23 Version [13.2.0](https://github.com/gooddata/gooddata-js/compare/v13.1.4...v13.2.0)
 


### PR DESCRIPTION
This allows the users without admin privileges to duplicate locked items.
Implemented as opt-in to maintain backwards compatibility.

<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

<!--
 Choose one of the three release types this change will be released as.
 When a change MUST be major:
 * backwards incompatible change in functionality - this includes:
   * removing/changing the order of parameters in a public function
   * removing/renaming a public module
 * backwards incompatible change in TypeScript types - this includes:
   * changing a type of a function parameters/return type to an incompatible type (e.g. number to string; number to number | string is fine)
 * major upgrade of ANY dependency
 * minor upgrade of typescript
 * changes in build logic that could make the output incompatible
 -->

**Proposed release type:** minor (see points 6. - 8. of the [semver spec](https://semver.org/#semantic-versioning-specification-semver))

# PR checklist

- [x] Change was tested using dev-release in Analytical Designer and Dashboards (if applicable). - tested in a custom application
- [x] Change is described in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Migration guide (for major update) is written to [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] The proposed release type is appropriate (see the comment in [PR template](../blob/master/.github/pull_request_template.md))
